### PR TITLE
feat(relayer): Add relayer region to the wallet v2 settings

### DIFF
--- a/wallets/react-wallet-v2/src/components/RelayRegionPicker.tsx
+++ b/wallets/react-wallet-v2/src/components/RelayRegionPicker.tsx
@@ -10,13 +10,19 @@ export default function AccountPicker() {
   }
 
   return (
-    <select value={relayerRegionURL} onChange={e => onSelect(e.currentTarget.value)} aria-label="relayerRegions">
-      {REGIONALIZED_RELAYER_ENDPOINTS.map((e, i) => {
+    <select
+      value={relayerRegionURL}
+      onChange={e => onSelect(e.currentTarget.value)}
+      aria-label="relayerRegions"
+    >
+      {REGIONALIZED_RELAYER_ENDPOINTS.map((endpoint, index) => {
         return (
-            <option key={i} value={e.value}>{e.label}</option>
-        );
+          <option key={index} value={endpoint.value}>
+            {endpoint.label}
+          </option>
+        )
       })}
-
     </select>
   )
 }
+

--- a/wallets/react-wallet-v2/src/components/RelayRegionPicker.tsx
+++ b/wallets/react-wallet-v2/src/components/RelayRegionPicker.tsx
@@ -1,0 +1,22 @@
+import { REGIONALIZED_RELAYER_ENDPOINTS } from '@/data/RelayerRegions'
+import SettingsStore from '@/store/SettingsStore'
+import { useSnapshot } from 'valtio'
+
+export default function AccountPicker() {
+  const { relayerRegionURL } = useSnapshot(SettingsStore.state)
+
+  function onSelect(value: string) {
+    SettingsStore.setRelayerRegionURL(value)
+  }
+
+  return (
+    <select value={relayerRegionURL} onChange={e => onSelect(e.currentTarget.value)} aria-label="relayerRegions">
+      {REGIONALIZED_RELAYER_ENDPOINTS.map((e, i) => {
+        return (
+            <option key={i} value={e.value}>{e.label}</option>
+        );
+      })}
+
+    </select>
+  )
+}

--- a/wallets/react-wallet-v2/src/data/RelayerRegions.ts
+++ b/wallets/react-wallet-v2/src/data/RelayerRegions.ts
@@ -1,0 +1,31 @@
+/**
+ * Types
+ */
+
+type RelayerType = {
+    value: string ;
+    label: string;
+};
+
+/**
+ * Relayer Regions
+ */
+export const REGIONALIZED_RELAYER_ENDPOINTS: RelayerType[] = [
+    {
+        value: "wss://relay.walletconnect.com",
+        label: "Default",
+    },
+
+    {
+        value: "wss://us-east-1.relay.walletconnect.com/",
+        label: "US",
+    },
+    {
+        value: "wss://eu-central-1.relay.walletconnect.com/",
+        label: "EU",
+    },
+    {
+        value: "wss://ap-southeast-1.relay.walletconnect.com/",
+        label: "Asia Pacific",
+    },
+];

--- a/wallets/react-wallet-v2/src/data/RelayerRegions.ts
+++ b/wallets/react-wallet-v2/src/data/RelayerRegions.ts
@@ -3,29 +3,29 @@
  */
 
 type RelayerType = {
-    value: string ;
-    label: string;
-};
+  value: string
+  label: string
+}
 
 /**
  * Relayer Regions
  */
 export const REGIONALIZED_RELAYER_ENDPOINTS: RelayerType[] = [
-    {
-        value: "wss://relay.walletconnect.com",
-        label: "Default",
-    },
+  {
+    value: 'wss://relay.walletconnect.com',
+    label: 'Default'
+  },
 
-    {
-        value: "wss://us-east-1.relay.walletconnect.com/",
-        label: "US",
-    },
-    {
-        value: "wss://eu-central-1.relay.walletconnect.com/",
-        label: "EU",
-    },
-    {
-        value: "wss://ap-southeast-1.relay.walletconnect.com/",
-        label: "Asia Pacific",
-    },
-];
+  {
+    value: 'wss://us-east-1.relay.walletconnect.com/',
+    label: 'US'
+  },
+  {
+    value: 'wss://eu-central-1.relay.walletconnect.com/',
+    label: 'EU'
+  },
+  {
+    value: 'wss://ap-southeast-1.relay.walletconnect.com/',
+    label: 'Asia Pacific'
+  }
+]

--- a/wallets/react-wallet-v2/src/hooks/useInitialization.ts
+++ b/wallets/react-wallet-v2/src/hooks/useInitialization.ts
@@ -4,10 +4,16 @@ import { createOrRestoreEIP155Wallet } from '@/utils/EIP155WalletUtil'
 import { createOrRestoreSolanaWallet } from '@/utils/SolanaWalletUtil'
 import { createOrRestorePolkadotWallet } from '@/utils/PolkadotWalletUtil'
 import { createSignClient } from '@/utils/WalletConnectUtil'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useSnapshot } from 'valtio'
 
 export default function useInitialization() {
   const [initialized, setInitialized] = useState(false)
+  const prevRelayerURLValue = useRef<string>("");
+
+  const { relayerRegionURL } = useSnapshot(
+    SettingsStore.state
+  )
 
   const onInitialize = useCallback(async () => {
     try {
@@ -21,19 +27,24 @@ export default function useInitialization() {
       SettingsStore.setSolanaAddress(solanaAddresses[0])
       SettingsStore.setPolkadotAddress(polkadotAddresses[0])
 
-      await createSignClient()
+      await createSignClient(relayerRegionURL)
+      prevRelayerURLValue.current = relayerRegionURL;
 
       setInitialized(true)
     } catch (err: unknown) {
       alert(err)
     }
-  }, [])
+  }, [relayerRegionURL])
 
   useEffect(() => {
     if (!initialized) {
       onInitialize()
     }
-  }, [initialized, onInitialize])
+    if(prevRelayerURLValue.current !== relayerRegionURL){
+      setInitialized(false)
+      onInitialize()
+    }
+  }, [initialized, onInitialize, relayerRegionURL])
 
   return initialized
 }

--- a/wallets/react-wallet-v2/src/hooks/useInitialization.ts
+++ b/wallets/react-wallet-v2/src/hooks/useInitialization.ts
@@ -9,11 +9,9 @@ import { useSnapshot } from 'valtio'
 
 export default function useInitialization() {
   const [initialized, setInitialized] = useState(false)
-  const prevRelayerURLValue = useRef<string>("");
+  const prevRelayerURLValue = useRef<string>('')
 
-  const { relayerRegionURL } = useSnapshot(
-    SettingsStore.state
-  )
+  const { relayerRegionURL } = useSnapshot(SettingsStore.state)
 
   const onInitialize = useCallback(async () => {
     try {
@@ -26,9 +24,9 @@ export default function useInitialization() {
       SettingsStore.setCosmosAddress(cosmosAddresses[0])
       SettingsStore.setSolanaAddress(solanaAddresses[0])
       SettingsStore.setPolkadotAddress(polkadotAddresses[0])
-
+      
       await createSignClient(relayerRegionURL)
-      prevRelayerURLValue.current = relayerRegionURL;
+      prevRelayerURLValue.current = relayerRegionURL
 
       setInitialized(true)
     } catch (err: unknown) {
@@ -40,7 +38,7 @@ export default function useInitialization() {
     if (!initialized) {
       onInitialize()
     }
-    if(prevRelayerURLValue.current !== relayerRegionURL){
+    if (prevRelayerURLValue.current !== relayerRegionURL) {
       setInitialized(false)
       onInitialize()
     }

--- a/wallets/react-wallet-v2/src/pages/settings.tsx
+++ b/wallets/react-wallet-v2/src/pages/settings.tsx
@@ -1,4 +1,5 @@
 import PageHeader from '@/components/PageHeader'
+import RelayRegionPicker from '@/components/RelayRegionPicker'
 import SettingsStore from '@/store/SettingsStore'
 import { cosmosWallets } from '@/utils/CosmosWalletUtil'
 import { eip155Wallets } from '@/utils/EIP155WalletUtil'
@@ -39,6 +40,16 @@ export default function SettingsPage() {
       <Row justify="space-between" align="center">
         <Switch checked={testNets} onChange={SettingsStore.toggleTestNets} />
         <Text>{testNets ? 'Enabled' : 'Disabled'}</Text>
+      </Row>
+
+      <Divider y={2} />
+
+      
+      <Row justify="space-between" align="center">
+        <Text h4 css={{ marginBottom: '$5' }}>
+          Relayer Region
+        </Text>        
+        <RelayRegionPicker/>
       </Row>
 
       <Divider y={2} />

--- a/wallets/react-wallet-v2/src/store/SettingsStore.ts
+++ b/wallets/react-wallet-v2/src/store/SettingsStore.ts
@@ -10,6 +10,7 @@ interface State {
   cosmosAddress: string
   solanaAddress: string
   polkadotAddress: string
+  relayerRegionURL: string
 }
 
 /**
@@ -21,7 +22,8 @@ const state = proxy<State>({
   eip155Address: '',
   cosmosAddress: '',
   solanaAddress: '',
-  polkadotAddress: ''
+  polkadotAddress: '',
+  relayerRegionURL: ''
 })
 
 /**
@@ -48,6 +50,10 @@ const SettingsStore = {
 
   setPolkadotAddress(polkadotAddress: string) {
     state.polkadotAddress = polkadotAddress
+  },
+
+  setRelayerRegionURL(relayerRegionURL: string) {
+    state.relayerRegionURL = relayerRegionURL
   },
 
   toggleTestNets() {

--- a/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
+++ b/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
@@ -2,10 +2,10 @@ import SignClient from '@walletconnect/sign-client'
 
 export let signClient: SignClient
 
-export async function createSignClient() {
+export async function createSignClient(relayerRegionURL: string) {
   signClient = await SignClient.init({
     projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
-    relayUrl: process.env.NEXT_PUBLIC_RELAY_URL ?? 'wss://relay.walletconnect.com',
+    relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAYER_URL,
     metadata: {
       name: 'React Wallet',
       description: 'React Wallet for WalletConnect',


### PR DESCRIPTION
Another PR related to #57, this PR is particularly for the `react-wallet-v2` app

[Loom Video](https://www.loom.com/share/aa4c756e71294fa99e4982d983addf01)

Process (Data)
1. Add `relayerRegionURL` + `setRelayerRegionURL` to settings store
2. Call `relayerRegionURL` through `valtio` through `useInitialization()`
3. Pass `relayerRegionURL` through to `createClient()`
4. Track the `prevRelayerURLValue` through `useRef`
5. Re-render when new `relayerURL` value is changed which instantiates a new `createClient()`

Process (Frontend)
1. Add types and utils list to `RelayerRegions` in the data folder
2. Create a `RelayRegionPicker` (Similar to AccountPicker) component.
3. SetState on the `select` value. Data should pass through 