### PR TITLE
Update newNs object to match Dapps session namespace

### DIFF
--- a/wallets/react-wallet-v2/src/pages/session.tsx
+++ b/wallets/react-wallet-v2/src/pages/session.tsx
@@ -63,8 +63,14 @@ export default function SessionPage() {
         'eip155:1:0x70012948c348CBF00806A3C79E3c5DAdFaAa347B',
         'eip155:137:0x70012948c348CBF00806A3C79E3c5DAdFaAa347B'
       ],
-      methods: ['personal_sign', 'eth_signTypedData', 'eth_sendTransaction'],
-      events: []
+      methods: [
+        'eth_sendTransaction',
+        'eth_signTransaction',
+        'eth_sign',
+        'personal_sign',
+        'eth_signTypedData'
+      ],
+      events: ['chainChanged', 'accountsChanged']
     }
   }
 


### PR DESCRIPTION
When updating the session, the console returns an error because in the react-dapp-v2 the session namespace has all five methods and events included. To update a session, you can only add chains, everything else has to be the same.
- Updated the `newNs` object to be the same as example dapp

The dapp uses all of the `EIP155` methods:
[Constants](https://github.com/WalletConnect/web-examples/blob/main/dapps/react-dapp-v2/src/constants/default.ts#:~:text=DEFAULT_EIP155_METHODS)
[Namespace where the methods are all set](https://github.com/WalletConnect/web-examples/blob/main/dapps/react-dapp-v2/src/helpers/namespaces.ts#:~:text=methods%3A%20getSupportedMethodsByNamespace(namespace)%2C)