### PR TITLE
Remove 'eth_sendRawTransaction' from const list

### DIFF
--- a/wallets/react-web3wallet/src/data/EIP155Data.ts
+++ b/wallets/react-web3wallet/src/data/EIP155Data.ts
@@ -85,6 +85,5 @@ export const EIP155_SIGNING_METHODS = {
   ETH_SIGN_TYPED_DATA: 'eth_signTypedData',
   ETH_SIGN_TYPED_DATA_V3: 'eth_signTypedData_v3',
   ETH_SIGN_TYPED_DATA_V4: 'eth_signTypedData_v4',
-  ETH_SEND_RAW_TRANSACTION: 'eth_sendRawTransaction',
   ETH_SEND_TRANSACTION: 'eth_sendTransaction'
 }


### PR DESCRIPTION
Removed instance of `eth_sendRawTransaction` since it's not being used anywhere in the example wallet.