### PR TITLE
fix(dapp): removes reliance on `caip-api` pkg for blockchain data

### DIFF
--- a/dapps/react-dapp-v2/package.json
+++ b/dapps/react-dapp-v2/package.json
@@ -24,7 +24,6 @@
     "axios": "^0.21.1",
     "blockies-ts": "^1.0.0",
     "bs58": "^5.0.0",
-    "caip-api": "^2.0.0-beta.1",
     "cosmos-wallet": "^1.2.0",
     "eth-sig-util": "^2.5.3",
     "ethereumjs-util": "^7.0.6",

--- a/dapps/react-dapp-v2/src/chains/cosmos.ts
+++ b/dapps/react-dapp-v2/src/chains/cosmos.ts
@@ -6,7 +6,39 @@ import {
   NamespaceMetadata,
   ChainMetadata,
   ChainRequestRender,
+  ChainsMap,
 } from "../helpers";
+
+export const CosmosChainData: ChainsMap = {
+  "cosmoshub-4": {
+    name: "Cosmos Hub",
+    id: "cosmos:cosmoshub-4",
+    rpc: ["https://rpc.cosmos.network"],
+    slip44: 118,
+    testnet: false,
+  },
+  "irishub-1": {
+    name: "Irisnet",
+    id: "cosmos:irishub-1",
+    rpc: ["https://rpc.irisnet.org"],
+    slip44: 566,
+    testnet: false,
+  },
+  "kava-4": {
+    name: "Kava",
+    id: "cosmos:kava-4",
+    rpc: ["https://kava4.data.kava.io"],
+    slip44: 459,
+    testnet: false,
+  },
+  "columbus-4": {
+    name: "Terra",
+    id: "cosmos:columbus-4",
+    rpc: [],
+    slip44: 330,
+    testnet: false,
+  },
+};
 
 export const CosmosMetadata: NamespaceMetadata = {
   "cosmoshub-4": {

--- a/dapps/react-dapp-v2/src/chains/eip155.ts
+++ b/dapps/react-dapp-v2/src/chains/eip155.ts
@@ -6,6 +6,7 @@ import {
   ChainRequestRender,
   convertHexToNumber,
   convertHexToUtf8,
+  ChainsMap,
 } from "../helpers";
 import { BLOCKCHAIN_LOGO_BASE_URL } from "../constants";
 
@@ -17,6 +18,100 @@ export const EIP155Colors = {
   polygon: "130, 71, 229",
   celo: "60, 203, 132",
   arbitrum: "44, 55, 75",
+};
+
+export const EIP155ChainData: ChainsMap = {
+  "1": {
+    name: "Ethereum Mainnet",
+    id: "eip155:1",
+    rpc: ["https://api.mycryptoapi.com/eth"],
+    slip44: 60,
+    testnet: false,
+  },
+  "5": {
+    name: "Ethereum Goerli",
+    id: "eip155:5",
+    rpc: ["https://rpc.goerli.mudit.blog"],
+    slip44: 60,
+    testnet: true,
+  },
+  "10": {
+    name: "Optimism Mainnet",
+    id: "eip155:10",
+    rpc: ["https://mainnet.optimism.io"],
+    slip44: 60,
+    testnet: false,
+  },
+  "42": {
+    name: "Ethereum Kovan",
+    id: "eip155:42",
+    rpc: ["https://kovan.poa.network"],
+    slip44: 60,
+    testnet: true,
+  },
+  "69": {
+    name: "Optimism Kovan",
+    id: "eip155:69",
+    rpc: ["https://kovan.optimism.io"],
+    slip44: 60,
+    testnet: true,
+  },
+  "100": {
+    name: "xDAI",
+    id: "eip155:100",
+    rpc: ["https://dai.poa.network"],
+    slip44: 60,
+    testnet: false,
+  },
+  "137": {
+    name: "Polygon Mainnet",
+    id: "eip155:137",
+    rpc: ["https://rpc-mainnet.matic.network"],
+    slip44: 60,
+    testnet: false,
+  },
+  "420": {
+    name: "Optimism Goerli",
+    id: "eip155:420",
+    rpc: ["https://goerli.optimism.io"],
+    slip44: 60,
+    testnet: true,
+  },
+  "42161": {
+    name: "Arbitrum One",
+    id: "eip155:42161",
+    rpc: ["https://arb1.arbitrum.io/rpc"],
+    slip44: 60,
+    testnet: false,
+  },
+  "42220": {
+    name: "Celo Mainnet",
+    id: "eip155:42220",
+    rpc: ["https://forno.celo.org"],
+    slip44: 52752,
+    testnet: false,
+  },
+  "44787": {
+    name: "Celo Alfajores",
+    id: "eip155:44787",
+    rpc: ["https://alfajores-forno.celo-testnet.org"],
+    slip44: 52752,
+    testnet: true,
+  },
+  "80001": {
+    name: "Polygon Mumbai",
+    id: "eip155:80001",
+    rpc: ["https://rpc-mumbai.matic.today"],
+    slip44: 60,
+    testnet: true,
+  },
+  "421611": {
+    name: "Arbitrum Rinkeby",
+    id: "eip155:421611",
+    rpc: ["https://rinkeby.arbitrum.io/rpc"],
+    slip44: 60,
+    testnet: true,
+  },
 };
 
 export const EIP155Metadata: NamespaceMetadata = {

--- a/dapps/react-dapp-v2/src/chains/elrond.ts
+++ b/dapps/react-dapp-v2/src/chains/elrond.ts
@@ -1,7 +1,5 @@
-import { ChainsMap } from "caip-api";
-import { NamespaceMetadata, ChainMetadata } from "../helpers";
+import { NamespaceMetadata, ChainMetadata, ChainsMap } from "../helpers";
 
-// TODO: add `elrond` namespace to `caip-api` package to avoid manual specification here.
 export const ElrondChainData: ChainsMap = {
   "1": {
     id: "elrond:1",

--- a/dapps/react-dapp-v2/src/chains/near.ts
+++ b/dapps/react-dapp-v2/src/chains/near.ts
@@ -1,10 +1,10 @@
 import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
-import { ChainsMap } from "caip-api";
 
 import {
   NamespaceMetadata,
   ChainMetadata,
   ChainRequestRender,
+  ChainsMap,
 } from "../helpers";
 
 export const NearMetadata: NamespaceMetadata = {
@@ -14,7 +14,6 @@ export const NearMetadata: NamespaceMetadata = {
   },
 };
 
-// TODO: add `near` namespace to `caip-api` package to avoid manual specification here.
 export const NearChainData: ChainsMap = {
   testnet: {
     name: "NEAR Testnet",

--- a/dapps/react-dapp-v2/src/chains/polkadot.ts
+++ b/dapps/react-dapp-v2/src/chains/polkadot.ts
@@ -1,10 +1,10 @@
-import { ChainsMap } from "caip-api";
 import { BLOCKCHAIN_LOGO_BASE_URL } from "../constants";
 import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
 import {
   NamespaceMetadata,
   ChainMetadata,
   ChainRequestRender,
+  ChainsMap,
 } from "../helpers";
 
 export const PolkadotChainData: ChainsMap = {

--- a/dapps/react-dapp-v2/src/chains/solana.ts
+++ b/dapps/react-dapp-v2/src/chains/solana.ts
@@ -1,7 +1,5 @@
-import { ChainsMap } from "caip-api";
-import { NamespaceMetadata, ChainMetadata } from "../helpers";
+import { NamespaceMetadata, ChainMetadata, ChainsMap } from "../helpers";
 
-// TODO: add `solana` namespace to `caip-api` package to avoid manual specification here.
 export const SolanaChainData: ChainsMap = {
   "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ": {
     id: "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",

--- a/dapps/react-dapp-v2/src/chains/tron.ts
+++ b/dapps/react-dapp-v2/src/chains/tron.ts
@@ -1,41 +1,39 @@
-import { ChainsMap } from 'caip-api';
-import { NamespaceMetadata, ChainMetadata } from '../helpers';
+import { NamespaceMetadata, ChainMetadata, ChainsMap } from "../helpers";
 
-// TODO: add `tron` namespace to `caip-api` package to avoid manual specification here.
 export const TronChainData: ChainsMap = {
-  '0x2b6653dc': {
-    id: 'tron:0x2b6653dc',
-    name: 'Tron Mainnet',
+  "0x2b6653dc": {
+    id: "tron:0x2b6653dc",
+    name: "Tron Mainnet",
     rpc: [],
     slip44: 195,
-    testnet: false
+    testnet: false,
   },
-  '0xcd8690dc': {
-    id: 'tron:0xcd8690dc',
-    name: 'Tron Testnet',
+  "0xcd8690dc": {
+    id: "tron:0xcd8690dc",
+    name: "Tron Testnet",
     rpc: [],
     slip44: 195,
-    testnet: true
-  }
+    testnet: true,
+  },
 };
 
 export const TronMetadata: NamespaceMetadata = {
   // Tron Mainnet
-  '0x2b6653dc': {
-    logo: 'https://tronscan.io/static/media/TRON.4a760cebd163969b2ee874abf2415e9a.svg',
-    rgb: '183, 62, 49',
+  "0x2b6653dc": {
+    logo: "https://tronscan.io/static/media/TRON.4a760cebd163969b2ee874abf2415e9a.svg",
+    rgb: "183, 62, 49",
   },
   // Tron TestNet
-  '0xcd8690dc': {
-    logo: 'https://tronscan.io/static/media/TRON.4a760cebd163969b2ee874abf2415e9a.svg',
-    rgb: '183, 62, 49',
-  }
+  "0xcd8690dc": {
+    logo: "https://tronscan.io/static/media/TRON.4a760cebd163969b2ee874abf2415e9a.svg",
+    rgb: "183, 62, 49",
+  },
 };
 
 export function getChainMetadata(chainId: string): ChainMetadata {
-  const reference = chainId.split(':')[1];
+  const reference = chainId.split(":")[1];
   const metadata = TronMetadata[reference];
-  if (typeof metadata === 'undefined') {
+  if (typeof metadata === "undefined") {
     throw new Error(`No chain metadata found for chainId: ${chainId}`);
   }
   return metadata;

--- a/dapps/react-dapp-v2/src/components/Blockchain.tsx
+++ b/dapps/react-dapp-v2/src/components/Blockchain.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren, FC } from "react";
 import styled from "styled-components";
-import { ChainData } from "caip-api";
 
 import Asset from "./Asset";
 import Button from "./Button";
@@ -14,6 +13,7 @@ import {
   AccountBalances,
   ChainMetadata,
   ChainNamespaces,
+  ChainData,
 } from "../helpers";
 import { fonts } from "../styles";
 

--- a/dapps/react-dapp-v2/src/contexts/ChainDataContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/ChainDataContext.tsx
@@ -1,4 +1,3 @@
-import { apiGetChainNamespace, ChainsMap } from "caip-api";
 import {
   createContext,
   ReactNode,
@@ -9,10 +8,12 @@ import {
 import { SolanaChainData } from "../chains/solana";
 import { PolkadotChainData } from "../chains/polkadot";
 import { ElrondChainData } from "../chains/elrond";
-import { TronChainData } from '../chains/tron';
+import { TronChainData } from "../chains/tron";
 
-import { ChainNamespaces, getAllChainNamespaces } from "../helpers";
+import { ChainNamespaces, ChainsMap, getAllChainNamespaces } from "../helpers";
 import { NearChainData } from "../chains/near";
+import { CosmosChainData } from "../chains/cosmos";
+import { EIP155ChainData } from "../chains/eip155";
 
 /**
  * Types
@@ -42,23 +43,32 @@ export function ChainDataContextProvider({
     await Promise.all(
       namespaces.map(async (namespace) => {
         let chains: ChainsMap | undefined;
-        try {
-          if (namespace === "solana") {
+        switch (namespace) {
+          case "solana":
             chains = SolanaChainData;
-          } else if (namespace === "polkadot") {
+            break;
+          case "polkadot":
             chains = PolkadotChainData;
-          } else if (namespace === "near") {
+            break;
+          case "near":
             chains = NearChainData;
-          } else if (namespace === "elrond") {
-            chains = ElrondChainData;  
-          } else if (namespace === 'tron') {
+            break;
+          case "elrond":
+            chains = ElrondChainData;
+            break;
+          case "tron":
             chains = TronChainData;
-          } else {
-            chains = await apiGetChainNamespace(namespace);
-          }
-        } catch (e) {
-          // ignore error
+            break;
+          case "cosmos":
+            chains = CosmosChainData;
+            break;
+          case "eip155":
+            chains = EIP155ChainData;
+            break;
+          default:
+            console.error("Unknown chain namespace: ", namespace);
         }
+
         if (typeof chains !== "undefined") {
           chainData[namespace] = chains;
         }

--- a/dapps/react-dapp-v2/src/helpers/types.ts
+++ b/dapps/react-dapp-v2/src/helpers/types.ts
@@ -1,5 +1,3 @@
-import { ChainsMap } from "caip-api";
-
 export interface AssetData {
   symbol: string;
   name: string;
@@ -9,13 +7,13 @@ export interface AssetData {
 
 export interface ChainData {
   name: string;
-  short_name: string;
-  chain: string;
-  network: string;
-  chain_id: number;
-  network_id: number;
-  rpc_url: string;
-  native_currency: AssetData;
+  id: string;
+  rpc: string[];
+  slip44: number;
+  testnet: boolean;
+}
+export interface ChainsMap {
+  [reference: string]: ChainData;
 }
 export interface TxData {
   from: string;

--- a/dapps/react-dapp-v2/yarn.lock
+++ b/dapps/react-dapp-v2/yarn.lock
@@ -2008,13 +2008,6 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@json-rpc-tools/types@^2.0.0-beta.0":
-  version "2.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@json-rpc-tools/types/-/types-2.0.0-beta.12.tgz#358f77c48a844a3f55169c2db3b35c6af1cf4e8b"
-  integrity sha512-UM8w0RnD4DjYql/HlThe051ivW2Q8ulWarr7ux5Aas1UsOmcGQEg4slQo46p+BXgh1Nth7SHWS2tVnW/UUnCwQ==
-  dependencies:
-    keyvaluestorage-interface "^1.0.0"
-
 "@lit-labs/ssr-dom-shim@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz#427e19a2765681fd83411cd72c55ba80a01e0523"
@@ -4906,20 +4899,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-caip-api@^2.0.0-beta.1:
-  version "2.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/caip-api/-/caip-api-2.0.0-beta.1.tgz#23877b880396f855fc2cd7892d02c597f2d62ba7"
-  integrity sha512-pwVXYfAIV3V0QhsKfvamIvsnn7lSmrotukmbXndOE2EsA0dos5W8MLadlpG2U+VSDghCVWI6cY9oJbBuXWj2gg==
-  dependencies:
-    "@json-rpc-tools/types" "^2.0.0-beta.0"
-    axios "^0.21.1"
-    caip "^0.9.2"
-
-caip@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/caip/-/caip-0.9.2.tgz#6aec668e459dc3a1830530f7bb8d06f0044a5391"
-  integrity sha512-o4aIUSR9lkn7B9lIw8Xgkj+hDh+S1PtsBphoSqP2Dt95gRWPniaqEpnPwiUEhaPQr84JzWIEm4Cck3lMZtIkTA==
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Context: https://walletconnect.slack.com/archives/C03RME3BS9L/p1677021657070509
- We've had some reports of some people seeing SSL errors when the dapp tries to resolve chain data via the `caip-api` pkg, which under the hood relies on the legacy `blockchain-api.xyz` as a data source.
- We still rely on a `blockchain-api.xyz` call to resolve some chain logos, but worst case scenario now is some broken logo assets if that domain can't be resolved, not a crashed dapp.

## How was this tested

- Explicitly blocked this domain in network inspector to recreate the issue and this fixes the crashing behaviour.