### PR TITLE
fix(dapp): makes sig validation compatible with ERC-1271

### DIFF
--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -310,16 +310,15 @@ export function JsonRpcContextProvider({
 
         //  split chainId
         const [namespace, reference] = chainId.split(":");
+        const rpc = rpcProvidersByChainId[Number(reference)];
 
-        const targetChainData = chainData[namespace][reference];
-
-        if (typeof targetChainData === "undefined") {
-          throw new Error(`Missing chain data for chainId: ${chainId}`);
+        if (typeof rpc === "undefined") {
+          throw new Error(
+            `Missing rpcProvider definition for chainId: ${chainId}`
+          );
         }
 
         const hashMsg = hashPersonalMessage(message);
-        const rpc =
-          rpcProvidersByChainId[Number(chainId.toString().split(":")[1])];
         const valid = await verifySignature(
           address,
           signature,
@@ -357,16 +356,15 @@ export function JsonRpcContextProvider({
 
         //  split chainId
         const [namespace, reference] = chainId.split(":");
+        const rpc = rpcProvidersByChainId[Number(reference)];
 
-        const targetChainData = chainData[namespace][reference];
-
-        if (typeof targetChainData === "undefined") {
-          throw new Error(`Missing chain data for chainId: ${chainId}`);
+        if (typeof rpc === "undefined") {
+          throw new Error(
+            `Missing rpcProvider definition for chainId: ${chainId}`
+          );
         }
 
         const hashMsg = hashPersonalMessage(message);
-        const rpc =
-          rpcProvidersByChainId[Number(chainId.toString().split(":")[1])];
         const valid = await verifySignature(
           address,
           signature,
@@ -400,9 +398,17 @@ export function JsonRpcContextProvider({
           },
         });
 
+        //  split chainId
+        const [namespace, reference] = chainId.split(":");
+        const rpc = rpcProvidersByChainId[Number(reference)];
+
+        if (typeof rpc === "undefined") {
+          throw new Error(
+            `Missing rpcProvider definition for chainId: ${chainId}`
+          );
+        }
+
         const hashedTypedData = hashTypedDataMessage(message);
-        const rpc =
-          rpcProvidersByChainId[Number(chainId.toString().split(":")[1])];
         const valid = await verifySignature(
           address,
           signature,

--- a/dapps/react-dapp-v2/src/helpers/api.ts
+++ b/dapps/react-dapp-v2/src/helpers/api.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import { AssetData } from "./types";
 
-const rpcProvidersByChainId: Record<number, any> = {
+export const rpcProvidersByChainId: Record<number, any> = {
   1: {
     name: "Ethereum Mainnet",
     baseURL: "https://mainnet.infura.io/v3/5dc0df7abe4645dfb06a9a8c39ede422",


### PR DESCRIPTION
- Fixes #117 
- Supersedes #140 
- Tested that existing signature validation still works as expected with https://react-wallet.walletconnect.com, on top of the additional ERC/EIP 1271 validation now accounted for.