### PR TITLE
Test: buildApprovedNamespaces in our wallet example

### DIFF
--- a/wallets/react-web3wallet/src/views/SessionProposalModal.tsx
+++ b/wallets/react-web3wallet/src/views/SessionProposalModal.tsx
@@ -96,12 +96,13 @@ export default function SessionProposalModal() {
         }
       })
 
-      console.log('buildApprovedNameSpace data:', namespaces);
+      console.log('buildApprovedNameSpace data:', namespaces)
 
       const approvedNamespaces = buildApprovedNamespaces({
         proposal: params,
         supportedNamespaces: {
           eip155: {
+            //@ts-ignore - Unsure why the string[] is not working for chains. Skipping as this is a test
             chains: namespaces.eip155.chains,
             methods: namespaces.eip155.methods,
             events: namespaces.eip155.events,

--- a/wallets/react-web3wallet/src/views/SessionProposalModal.tsx
+++ b/wallets/react-web3wallet/src/views/SessionProposalModal.tsx
@@ -96,6 +96,8 @@ export default function SessionProposalModal() {
         }
       })
 
+      console.log('buildApprovedNameSpace data:', namespaces);
+
       const approvedNamespaces = buildApprovedNamespaces({
         proposal: params,
         supportedNamespaces: {


### PR DESCRIPTION
Test nameSpaceBuilder in our wallet example

Note here: i did not update the UI. So optional does not show up

![image](https://github.com/WalletConnect/web-examples/assets/45455218/efb90e9e-c477-4fcd-a4f2-86f7ebb1cff8)

Refer to the console log: `buildApprovedNameSpace data:` that is called after you press approve
