### PR TITLE
fix: corrected e2e navigation tags

### DIFF
--- a/wallets/react-wallet-v2/README.md
+++ b/wallets/react-wallet-v2/README.md
@@ -96,6 +96,7 @@ url: `/pairings`
 url: `/`
 | Key | Description |
 | ----------- | ----------- |
+| `account-picker` | Account drop down selector|
 | `chain-card-${chain id}` | Chain card by chain id |
 | `chain-switch-button-${chain id}` | Chain switch button |
 | `chain-switch-button-${chain id}` | Chain copy button |

--- a/wallets/react-wallet-v2/src/components/AccountPicker.tsx
+++ b/wallets/react-wallet-v2/src/components/AccountPicker.tsx
@@ -26,7 +26,7 @@ export default function AccountPicker() {
   }
 
   return (
-    <select value={account} onChange={e => onSelect(e.currentTarget.value)} aria-label="addresses">
+    <select value={account} onChange={e => onSelect(e.currentTarget.value)} aria-label="addresses" data-testid="account-picker">
       <option value={0}>Account 1</option>
       <option value={1}>Account 2</option>
     </select>

--- a/wallets/react-wallet-v2/src/components/Navigation.tsx
+++ b/wallets/react-wallet-v2/src/components/Navigation.tsx
@@ -5,20 +5,20 @@ import Link from 'next/link'
 export default function Navigation() {
   return (
     <Row justify="space-between" align="center">
-      <Link href="/" passHref data-testid="accounts">
-        <a className="navLink">
+      <Link href="/" passHref>
+        <a className="navLink" data-testid="accounts">
           <Image alt="accounts icon" src="/icons/accounts-icon.svg" width={27} height={27} />
         </a>
       </Link>
 
-      <Link href="/sessions" passHref data-testid="sessions">
-        <a className="navLink">
+      <Link href="/sessions" passHref>
+        <a className="navLink" data-testid="sessions">
           <Image alt="sessions icon" src="/icons/sessions-icon.svg" width={27} height={27} />
         </a>
       </Link>
 
-      <Link href="/walletconnect" passHref data-testid="wc-connect">
-        <a className="navLink">
+      <Link href="/walletconnect" passHref>
+        <a className="navLink" data-testid="wc-connect">
           <Avatar
             size="lg"
             css={{ cursor: 'pointer' }}
@@ -35,14 +35,14 @@ export default function Navigation() {
         </a>
       </Link>
 
-      <Link href="/pairings" passHref data-testid="pairings">
-        <a className="navLink">
+      <Link href="/pairings" passHref>
+        <a className="navLink" data-testid="pairings">
           <Image alt="pairings icon" src="/icons/pairings-icon.svg" width={25} height={25} />
         </a>
       </Link>
 
-      <Link href="/settings" passHref data-testid="settings">
-        <a className="navLink">
+      <Link href="/settings" passHref>
+        <a className="navLink" data-testid="settings">
           <Image alt="settings icon" src="/icons/settings-icon.svg" width={27} height={27} />
         </a>
       </Link>


### PR DESCRIPTION
Minor changes 
The `data-testid` tags were placed in next/link elements
I did not expect this to be an issue, but it was

_next/link_ does not actually render `<Link>` as an element
It modifies the `<a>` tag inside of it with the href passed 
Which would remove the `data-testid` tags from the dom