### PR TITLE
fix: Generate EIP-712 messages for active chain id

### DIFF
--- a/dapps/react-dapp-v2-with-ethers/src/helpers/eip712.ts
+++ b/dapps/react-dapp-v2-with-ethers/src/helpers/eip712.ts
@@ -1,5 +1,5 @@
 // From spec: https://eips.ethereum.org/EIPS/eip-712
-const example = {
+export const generateEip712Message = (chainId = 1) => ({
   types: {
     EIP712Domain: [
       { name: "name", type: "string" },
@@ -21,7 +21,7 @@ const example = {
   domain: {
     name: "Ether Mail",
     version: "1",
-    chainId: 1,
+    chainId,
     verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
   },
   message: {
@@ -29,8 +29,4 @@ const example = {
     to: { name: "Bob", wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" },
     contents: "Hello, Bob!",
   },
-};
-
-export const eip712 = {
-  example,
-};
+});

--- a/dapps/react-dapp-v2-with-ethers/src/pages/index.tsx
+++ b/dapps/react-dapp-v2-with-ethers/src/pages/index.tsx
@@ -13,8 +13,8 @@ import Modal from "./../components/Modal";
 import { DEFAULT_MAIN_CHAINS, DEFAULT_TEST_CHAINS } from "./../constants";
 import {
   AccountAction,
-  eip712,
   formatTestTransaction,
+  generateEip712Message,
   getLocalStorageTestnetFlag,
   hashPersonalMessage,
   hashTypedDataMessage,
@@ -161,7 +161,7 @@ const Home: NextPage = () => {
     const hexMsg = encoding.utf8ToHex(msg, true);
     const [address] = await web3Provider.listAccounts();
     const signature = await web3Provider.send("personal_sign", [hexMsg, address]);
-    const hashMsg = hashPersonalMessage(msg)
+    const hashMsg = hashPersonalMessage(msg);
     const valid = await verifySignature(address, signature, hashMsg, web3Provider);
     return {
       method: "personal_sign",
@@ -193,7 +193,8 @@ const Home: NextPage = () => {
       throw new Error("web3Provider not connected");
     }
 
-    const message = JSON.stringify(eip712.example);
+    const { chainId } = await web3Provider.getNetwork();
+    const message = JSON.stringify(generateEip712Message(chainId));
 
     const [address] = await web3Provider.listAccounts();
 

--- a/dapps/react-dapp-v2-with-web3js/src/helpers/eip712.ts
+++ b/dapps/react-dapp-v2-with-web3js/src/helpers/eip712.ts
@@ -1,5 +1,5 @@
 // From spec: https://eips.ethereum.org/EIPS/eip-712
-const example = {
+export const generateEip712Message = (chainId = 1) => ({
   types: {
     EIP712Domain: [
       { name: "name", type: "string" },
@@ -21,7 +21,7 @@ const example = {
   domain: {
     name: "Ether Mail",
     version: "1",
-    chainId: 1,
+    chainId,
     verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
   },
   message: {
@@ -29,8 +29,4 @@ const example = {
     to: { name: "Bob", wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" },
     contents: "Hello, Bob!",
   },
-};
-
-export const eip712 = {
-  example,
-};
+});

--- a/dapps/react-dapp-v2-with-web3js/src/pages/index.tsx
+++ b/dapps/react-dapp-v2-with-web3js/src/pages/index.tsx
@@ -13,7 +13,7 @@ import Modal from "./../components/Modal";
 import { DEFAULT_MAIN_CHAINS, DEFAULT_TEST_CHAINS } from "./../constants";
 import {
   AccountAction,
-  eip712,
+  generateEip712Message,
   getLocalStorageTestnetFlag,
   setLocaleStorageTestnetFlag,
 } from "./../helpers";
@@ -188,7 +188,9 @@ export default function App() {
       throw new Error("web3Provider.currentProvider is not set");
     }
 
-    const message = JSON.stringify(eip712.example);
+    const chainId = await web3Provider.eth.getChainId();
+    const eip712Message = generateEip712Message(chainId);
+    const message = JSON.stringify(eip712Message);
 
     const [address] = await web3Provider.eth.getAccounts();
 
@@ -208,11 +210,11 @@ export default function App() {
     // will throw due to "unused" `EIP712Domain` type.
     // See: https://github.com/ethers-io/ethers.js/issues/687#issuecomment-714069471
     const { EIP712Domain, ...nonDomainTypes }: Record<string, TypedDataField[]> =
-      eip712.example.types;
+      eip712Message.types;
 
     const valid =
       utils
-        .verifyTypedData(eip712.example.domain, nonDomainTypes, eip712.example.message, signature)
+        .verifyTypedData(eip712Message.domain, nonDomainTypes, eip712Message.message, signature)
         .toLowerCase() === address.toLowerCase();
 
     return {

--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -29,8 +29,8 @@ import {
 import { PactNumber } from "@kadena/pactjs";
 import {
   KadenaAccount,
-  eip712,
   formatTestTransaction,
+  generateEip712Message,
   getLocalStorageTestnetFlag,
   getProviderUrl,
   hashPersonalMessage,
@@ -411,7 +411,13 @@ export function JsonRpcContextProvider({
     ),
     testSignTypedData: _createJsonRpcRequestHandler(
       async (chainId: string, address: string) => {
-        const message = JSON.stringify(eip712.example);
+        //  split chainId
+        const [namespace, reference] = chainId.split(":");
+        const rpc = rpcProvidersByChainId[Number(reference)];
+
+        const message = JSON.stringify(
+          generateEip712Message(Number(reference))
+        );
 
         // eth_signTypedData params
         const params = [address, message];
@@ -425,10 +431,6 @@ export function JsonRpcContextProvider({
             params,
           },
         });
-
-        //  split chainId
-        const [namespace, reference] = chainId.split(":");
-        const rpc = rpcProvidersByChainId[Number(reference)];
 
         if (typeof rpc === "undefined") {
           throw new Error(
@@ -454,7 +456,13 @@ export function JsonRpcContextProvider({
     ),
     testSignTypedDatav4: _createJsonRpcRequestHandler(
       async (chainId: string, address: string) => {
-        const message = JSON.stringify(eip712.example);
+        //  split chainId
+        const [namespace, reference] = chainId.split(":");
+        const rpc = rpcProvidersByChainId[Number(reference)];
+
+        const message = JSON.stringify(
+          generateEip712Message(Number(reference))
+        );
         console.log("eth_signTypedData_v4");
 
         // eth_signTypedData_v4 params
@@ -469,10 +477,6 @@ export function JsonRpcContextProvider({
             params,
           },
         });
-
-        //  split chainId
-        const [namespace, reference] = chainId.split(":");
-        const rpc = rpcProvidersByChainId[Number(reference)];
 
         if (typeof rpc === "undefined") {
           throw new Error(

--- a/dapps/react-dapp-v2/src/helpers/eip712.ts
+++ b/dapps/react-dapp-v2/src/helpers/eip712.ts
@@ -1,5 +1,5 @@
 // From spec: https://eips.ethereum.org/EIPS/eip-712
-const example = {
+export const generateEip712Message = (chainId = 1) => ({
   types: {
     EIP712Domain: [
       { name: "name", type: "string" },
@@ -21,7 +21,7 @@ const example = {
   domain: {
     name: "Ether Mail",
     version: "1",
-    chainId: 1,
+    chainId,
     verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
   },
   message: {
@@ -29,8 +29,4 @@ const example = {
     to: { name: "Bob", wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" },
     contents: "Hello, Bob!",
   },
-};
-
-export const eip712 = {
-  example,
-};
+});


### PR DESCRIPTION
The `domain.chainId` attribute of the EIP-712 messages should match the current active chain of the client as specified on the [EIP-712 spec](https://eips.ethereum.org/EIPS/eip-712):
> uint256 chainId the [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain id. The user-agent should refuse signing if it does not match the currently active chain.

The [Wagmi](https://github.com/wagmi-dev/wagmi) library for instance throws an error when the `chainId` specified on the EIP-712 message does not match the current active chain (see code [here](https://github.com/wagmi-dev/wagmi/blob/main/packages/core/src/actions/accounts/signTypedData.ts#L39)).

- Update the EIP-712 message example to set the correct `domain.chainId` attribute for the active chain