### PR TITLE
Check for the whole chain identifier ( namespace + ":" + reference )

### DIFF
--- a/dapps/react-dapp-v2/src/constants/default.ts
+++ b/dapps/react-dapp-v2/src/constants/default.ts
@@ -125,6 +125,8 @@ export enum DEFAULT_MULTIVERSX_METHODS {
   MULTIVERSX_SIGN_MESSAGE = "mvx_signMessage",
   MULTIVERSX_SIGN_LOGIN_TOKEN = "mvx_signLoginToken",
   MULTIVERSX_SIGN_NATIVE_AUTH_TOKEN = "mvx_signNativeAuthToken",
+  MULTIVERSX_CANCEL_ACTION = "mvx_cancelAction"
+
 }
 
 export enum DEFAULT_MULTIVERSX_EVENTS {}

--- a/dapps/react-dapp-v2/src/constants/default.ts
+++ b/dapps/react-dapp-v2/src/constants/default.ts
@@ -126,7 +126,6 @@ export enum DEFAULT_MULTIVERSX_METHODS {
   MULTIVERSX_SIGN_LOGIN_TOKEN = "mvx_signLoginToken",
   MULTIVERSX_SIGN_NATIVE_AUTH_TOKEN = "mvx_signNativeAuthToken",
   MULTIVERSX_CANCEL_ACTION = "mvx_cancelAction"
-
 }
 
 export enum DEFAULT_MULTIVERSX_EVENTS {}

--- a/wallets/react-wallet-v2/src/components/ChainDataMini.tsx
+++ b/wallets/react-wallet-v2/src/components/ChainDataMini.tsx
@@ -12,13 +12,13 @@ import { Card, Row, styled, Image, Avatar } from '@nextui-org/react'
 import { ReactNode, useMemo } from 'react'
 
 interface Props {
-  chainId?: string | number
+  chainId?: string // namespace + ":" + reference
 }
 
 // const StyledLogo = styled(Image, {})
 
 export default function ChainDataMini({ chainId }: Props) {
-  const chainData = useMemo(() => getChainData(chainId!), [chainId])
+  const chainData = useMemo(() => getChainData(chainId), [chainId])
   console.log(chainData)
 
   if (!chainData) return <></>

--- a/wallets/react-wallet-v2/src/data/MultiversxData.ts
+++ b/wallets/react-wallet-v2/src/data/MultiversxData.ts
@@ -47,5 +47,6 @@ export const MULTIVERSX_SIGNING_METHODS = {
   MULTIVERSX_SIGN_TRANSACTIONS: 'mvx_signTransactions',
   MULTIVERSX_SIGN_MESSAGE: 'mvx_signMessage',
   MULTIVERSX_SIGN_LOGIN_TOKEN: 'mvx_signLoginToken',
-  MULTIVERSX_SIGN_NATIVE_AUTH_TOKEN: 'mvx_signNativeAuthToken'
+  MULTIVERSX_SIGN_NATIVE_AUTH_TOKEN: 'mvx_signNativeAuthToken',
+  MULTIVERSX_CANCEL_ACTION: 'mvx_cancelAction'
 }

--- a/wallets/react-wallet-v2/src/data/MultiversxData.ts
+++ b/wallets/react-wallet-v2/src/data/MultiversxData.ts
@@ -13,7 +13,7 @@ export const MULTIVERSX_MAINNET_CHAINS = {
     logo: '/chain-logos/multiversx-1.svg',
     rgb: '43, 45, 46',
     rpc: '',
-    namespace: 'mutiversx'
+    namespace: 'mvx'
   }
 }
 
@@ -24,7 +24,7 @@ export const MULTIVERSX_TEST_CHAINS = {
     logo: '/chain-logos/multiversx-1.svg',
     rgb: '43, 45, 46',
     rpc: '',
-    namespace: 'mutiversx'
+    namespace: 'mvx'
   }
   // Keep only one Test Chain visible
   // 'mvx:T': {
@@ -32,7 +32,8 @@ export const MULTIVERSX_TEST_CHAINS = {
   //   name: 'MultiversX Testnet',
   //   logo: '/chain-logos/multiversx-1.svg',
   //   rgb: '43, 45, 46',
-  //   rpc: ''
+  //   rpc: '',
+  //   namespace: 'mvx'
   // }
 }
 

--- a/wallets/react-wallet-v2/src/data/chainsUtil.ts
+++ b/wallets/react-wallet-v2/src/data/chainsUtil.ts
@@ -20,8 +20,10 @@ export const ALL_CHAINS = {
   ...TRON_CHAINS
 }
 
-export function getChainData(chainId: string | number) {
+export function getChainData(chainId?: string) {
   if (!chainId) return
-  chainId = chainId.toString().includes(':') ? chainId.toString().split(':')[1] : chainId
-  return Object.values(ALL_CHAINS).find(chain => chain.chainId == chainId)
+  const [namespace, reference] = chainId.toString().split(':')
+  return Object.values(ALL_CHAINS).find(
+    chain => chain.chainId == reference && chain.namespace === namespace
+  )
 }

--- a/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
+++ b/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
@@ -102,7 +102,7 @@ export default function SessionProposalModal() {
         events: [],
         accounts: kadenaChains.map(chain => `${chain}:${kadenaAddresses[0]}`).flat()
       },
-      multiversx: {
+      mvx: {
         chains: multiversxChains,
         methods: multiversxMethods,
         events: [],
@@ -198,7 +198,7 @@ export default function SessionProposalModal() {
         return cosmosAddresses[0]
       case 'kadena':
         return kadenaAddresses[0]
-      case 'multiversx':
+      case 'mvx':
         return multiversxAddresses[0]
       case 'near':
         return nearAddresses[0]
@@ -324,9 +324,13 @@ export default function SessionProposalModal() {
           </Row>
           {supportedChains.length &&
             supportedChains.map((chain, i) => {
+              if (!chain) {
+                return <></>
+              }
+
               return (
                 <Row key={i}>
-                  <ChainDataMini key={i} chainId={chain?.chainId!} />
+                  <ChainDataMini key={i} chainId={`${chain?.namespace}:${chain?.chainId}`} />
                 </Row>
               )
             })}

--- a/wallets/react-wallet-v2/src/views/SessionSignMultiversxModal.tsx
+++ b/wallets/react-wallet-v2/src/views/SessionSignMultiversxModal.tsx
@@ -67,7 +67,7 @@ export default function SessionSignMultiversxModal() {
 
   return (
     <RequestModal
-      intention="sign a Mtvx message"
+      intention="sign a MultiversX message"
       metadata={requestSession.peer.metadata}
       onApprove={onApprove}
       onReject={onReject}


### PR DESCRIPTION
Check for the whole chain identifier ( `namespace` + ":" + `reference` ) in `getChainData` instead of just reference(chainId) to avoid conflicts between chains that share the same reference ( `testnet` for NEAR Testnet and Tezos Testnet or `1` for Ethereum Mainnet and MultiversX Mainnet)

Updated the MultiversX namespace to the CAIP-2 compliant `mvx` used in the ecosystem