### PR TITLE
Add accountsChanged and chainChanged events for NEAR

### DIFF
--- a/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
+++ b/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
@@ -111,7 +111,7 @@ export default function SessionProposalModal() {
       near: {
         chains: nearChains,
         methods: nearMethods,
-        events: [],
+        events: ['accountsChanged', 'chainChanged'],
         accounts: nearChains.map(chain => `${chain}:${nearAddresses[0]}`).flat()
       },
       polkadot: {


### PR DESCRIPTION
# Description

This PR is added because when trying to connect from dApps that use the WalletConnect  [Near Wallet Selector](https://github.com/near/wallet-selector) such as [GuestBook Example](https://near.github.io/wallet-selector/) the pairing is failing because of mismatch of events.

The proposal from near/wallet-selector by default adds the `accountsChanged` and `chainChanged` to the events array but looking at the [SessionProposalModal.tsx#L114](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx#L114) it assumes that the supported events should be an `[]` empty array.

This is resulting in [buildApprovedNamespaces](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx#L240) to throw an error.

Fixes this error 
![image](https://github.com/WalletConnect/web-examples/assets/95851345/02481029-35a7-4634-965e-abba171314fc)
