### PR TITLE
feat: wallet connection via deeplink

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/pages/walletconnect.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/walletconnect.tsx
@@ -3,11 +3,12 @@ import PageHeader from '@/components/PageHeader'
 import QrReader from '@/components/QrReader'
 import { web3wallet } from '@/utils/WalletConnectUtil'
 import { Button, Input, Loading, Text } from '@nextui-org/react'
-import { Fragment, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { styledToast } from '@/utils/HelperUtil'
 import ModalStore from '@/store/ModalStore'
 
-export default function WalletConnectPage() {
+export default function WalletConnectPage(params: { deepLink?: string }) {
+  const { deepLink } = params
   const [uri, setUri] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -37,6 +38,12 @@ export default function WalletConnectPage() {
       setUri('')
     }
   }
+
+  useMemo(() => {
+    if (deepLink) {
+      onConnect(deepLink)
+    }
+  }, [deepLink])
 
   return (
     <Fragment>

--- a/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
@@ -1,0 +1,22 @@
+import { Text } from '@nextui-org/react'
+import { Fragment } from 'react'
+import { useRouter } from 'next/router'
+import WalletConnectPage from './walletconnect'
+
+export default function DeepLinkPairingPage() {
+  const router = useRouter()
+
+  const uri = router.query.uri as string
+
+  if (!uri) {
+    return (
+      <Fragment>
+        <Text css={{ opacity: '0.5', textAlign: 'center', marginTop: '$20' }}>
+          No URI provided via `?uri=` params
+        </Text>
+      </Fragment>
+    )
+  }
+
+  return <WalletConnectPage deepLink={uri} />
+}


### PR DESCRIPTION
Added new page `/wc` that accepts deeplinks (`?uri=wc%3Ab2222ed98bec37db97d17028849eb3a3d0d5179cac4cfc036e6602d3e32bd87f%402%3Frelay-protocol%3Dirn%26symKey%3D3081499b0c00c3674b648f3d3262ae8aa689639166a0c5ba69f1cad24d171252`) to initialize connection instead of only copy/paste of qr