### PR TITLE
Display smart account address on permission modal with eoa wallet add…

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/SmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SmartAccountLib.ts
@@ -29,7 +29,13 @@ export class SmartAccountLib {
   }
 
   // -- Public ------------------------------------------------------------------
-
+  public getSmartAccountAddress = async () => {
+    if (!this.address) {
+      const smartAccountClient = await this.getSmartAccountClient();
+      this.address = smartAccountClient.account.address
+    }
+    return this.address
+  }
 
   // -- Private -----------------------------------------------------------------
   private getWalletConnectTransport = () => http(


### PR DESCRIPTION
![Screenshot 2024-02-01 at 14 10 08](https://github.com/WalletConnect/web-examples/assets/9341833/c6e7b472-0256-4987-8a44-efa96ad44e7d)

On requested permission modal, in case there's a smart account deployed, display its address right under the wallet address.