### PR TITLE
fix: smart account creation on session requests

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/components/SmartAccountCard.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/SmartAccountCard.tsx
@@ -100,7 +100,6 @@ export default function SmartAccountCard({
       >
         {activeChainId === chainId ? `✅` : `🔄`}
       </Button>
-
       {smartAccountAddress ? (
         <>
           <Text h5 css={{ marginTop: 20 }}>
@@ -109,15 +108,17 @@ export default function SmartAccountCard({
           <Text small css={{ marginTop: 5 }}>
             {smartAccountAddress}
           </Text>
-          <Button
-            size="md"
-            css={{ marginTop: 20, width: '100%' }}
-            onClick={sendTestTransaction}
-            disabled={!isActiveChain || loading}
-          >
-            {loading ? <Loading size="sm" /> : 'Send Test TX'}
-          </Button>
         </>
+      ) : null}
+      {isDeployed && smartAccountAddress ? (
+        <Button
+          size="md"
+          css={{ marginTop: 20, width: '100%' }}
+          onClick={sendTestTransaction}
+          disabled={!isActiveChain || loading}
+        >
+          {loading ? <Loading size="sm" /> : 'Send Test TX'}
+        </Button>
       ) : (
         <>
           <Button

--- a/advanced/wallets/react-wallet-v2/src/hooks/useSmartAccount.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useSmartAccount.ts
@@ -58,9 +58,9 @@ export default function useSmartAccount(signerPrivateKey: Hex, chain: Chain) {
     }, [signerPrivateKey, smartAccountSponsorshipEnabled, chain])
 
     useEffect(() => {
-        client?.checkIfSmartAccountDeployed()
-            .then((deployed: boolean) => {
-                setIsDeployed(deployed)
+        client?.init()
+            .then(() => {
+                setIsDeployed(client?.isDeployed)
                 setAddress(client?.address)
             })
     }, [client, chain])

--- a/advanced/wallets/react-wallet-v2/src/lib/SmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SmartAccountLib.ts
@@ -162,8 +162,13 @@ export class SmartAccountLib {
   }
 
   // -- Public ------------------------------------------------------------------
-  public getAccount = async () =>
-    privateKeyToSafeSmartAccount(this.publicClient, {
+  public async init() {
+    await this.checkIfSmartAccountDeployed()
+    this.address = (await this.getAccount()).address
+  }
+
+  public getAccount = async () => {
+    const account = await privateKeyToSafeSmartAccount(this.publicClient, {
       privateKey: this.#signerPrivateKey,
       safeVersion: '1.4.1', // simple version
       entryPoint: ENTRYPOINT_ADDRESSES[this.chain.name], // global entrypoint
@@ -178,6 +183,10 @@ export class SmartAccountLib {
         }
       ]
     })
+    this.address = account.address
+    
+    return account;
+  }
 
   static isSmartAccount = async (address: Address, chain: Chain) => {
     const client = createPublicClient({
@@ -263,9 +272,7 @@ export class SmartAccountLib {
     this.isDeployed = Boolean(bytecode)
     
     console.log(`Smart Account Deployed: ${this.isDeployed}`)
-    if (this.isDeployed) {
-      this.address = smartAccountClient.account.address
-    }
+  
     return this.isDeployed;
 }
 


### PR DESCRIPTION
## Summary
Smart accounts were being incorrectly instanced by not providing the correct chain. 

- Extracted chain and account information from the namespace and added a couple of validations before appending smart accounts to the accounts entry of the session response.
- Minor fix on smart account client to allow to always have an address
- Minor change in SmartAccountCard  component to always show SA address.

## Known issues
- If multiple chains are provided during session request, only the first chain's smart account is being instanced. Need to look into it but think I can do in separate PR