### PR TITLE
feat(ui-test): enable verify to be covered

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/components/ProjectInfoCard.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/ProjectInfoCard.tsx
@@ -67,7 +67,12 @@ export default function ProjectInfoCard({ metadata, intention }: IProps) {
       </Row>
       <Row align="center">
         <Col>
-          {validation == 'VALID' ? <StyledVerifiedIcon src="/icons/verified-domain.svg" /> : null}
+          {validation == 'VALID' ? (
+            <StyledVerifiedIcon
+              src="/icons/verified-domain.svg"
+              data-testid="session-info-verified"
+            />
+          ) : null}
           <Link style={{ verticalAlign: 'middle' }} href={url} data-testid="session-info-card-url">
             <StyledLink>{url}</StyledLink>
           </Link>


### PR DESCRIPTION
Adding the `data-testid` attribute such that Playwright can properly assert on it.

# Testing

Confirmed in preview link.

<img width="1249" alt="Screenshot 2024-02-09 at 5 44 09 AM" src="https://github.com/WalletConnect/web-examples/assets/966091/4dcea8ab-3ad5-47e9-948d-182a81718772">
