### PR TITLE
fix: catch namespace builder exception

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/hooks/usePriorityAccounts.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/usePriorityAccounts.ts
@@ -8,7 +8,7 @@ import { SessionTypes } from '@walletconnect/types'
 import { useSnapshot } from 'valtio'
 
 interface IProps {
-  namespaces: SessionTypes.Namespaces
+  namespaces?: SessionTypes.Namespaces
 }
 
 export default function usePriorityAccounts({ namespaces }: IProps) {
@@ -19,6 +19,7 @@ export default function usePriorityAccounts({ namespaces }: IProps) {
     safeSmartAccountAddress,
     safeSmartAccountEnabled
   } = useSnapshot(SettingsStore.state)
+  if (!namespaces) return []
 
   if (smartAccountEnabled) {
     if (safeSmartAccountEnabled) {

--- a/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
+++ b/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
@@ -226,17 +226,22 @@ export default function SessionProposalModal() {
     }
   }, [])
 
-  const namespaces = buildApprovedNamespaces({
-    proposal: proposal.params,
-    supportedNamespaces
-  })
+  const namespaces = useMemo(() => {
+    try {
+      // the builder throws an exception if required namespaces are not supported
+      return buildApprovedNamespaces({
+        proposal: proposal.params,
+        supportedNamespaces
+      })
+    } catch (e) {}
+  }, [proposal.params, supportedNamespaces])
 
   const reorderedEip155Accounts = usePriorityAccounts({ namespaces })
   console.log('Reordrered accounts', { reorderedEip155Accounts })
 
   // Hanlde approve action, construct session namespace
   const onApprove = useCallback(async () => {
-    if (proposal) {
+    if (proposal && namespaces) {
       setIsLoadingApprove(true)
 
       try {


### PR DESCRIPTION
`buildApprovedNamespaces` throws when required namespaces are not supported by the wallet and must be catched to avoid unhandled exceptions