### PR TITLE
chore: enable trace logs for react-wallet

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
@@ -5,7 +5,8 @@ export let web3wallet: IWeb3Wallet
 export async function createWeb3Wallet(relayerRegionURL: string) {
   const core = new Core({
     projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
-    relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAY_URL
+    relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAY_URL,
+    logger: "trace"
   })
   web3wallet = await Web3Wallet.init({
     core,


### PR DESCRIPTION
Enable trace logs for React Wallet so Playwright can easily access them for debugging test flakiness. [Slack conversation](https://walletconnect.slack.com/archives/C03RME3BS9L/p1711561028218789?thread_ts=1711559317.364129&cid=C03RME3BS9L)