### PR TITLE
chore(renovate): only rebase on conflict

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ":semanticCommits",
     ":semanticCommitScope(deps)"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
## Context

- Renovatebot is very trigger-happy with rebasing its PRs immediately when it falls behind the base branch, even if not conflicted.
- This is causing Vercel deployment floods unnecessarily and clogging up the deployment pipeline in other Vercel projects outside of our examples
- See: https://docs.renovatebot.com/updating-rebasing/

### Solution

- Only rebase when conflicted. If that still doesn't help we can move to `rebaseWhen: "never"` for full manual control