### PR TITLE
feat: add EIP5792 batch transaction on EOA

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/data/EIP5792Data.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/EIP5792Data.ts
@@ -34,25 +34,31 @@ export type SendCallsParams = {
   capabilities?: Record<string, any> | undefined
 }
 
+export type CallReceipt = {
+  logs: {
+    address: `0x${string}`
+    data: `0x${string}`
+    topics: `0x${string}`[]
+  }[]
+  status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
+  blockHash: `0x${string}`
+  blockNumber: `0x${string}`
+  gasUsed: `0x${string}`
+  transactionHash: `0x${string}`
+}
+
 export type GetCallsResult = {
   status: 'PENDING' | 'CONFIRMED'
-  receipts?: {
-    logs: {
-      address: `0x${string}`
-      data: `0x${string}`
-      topics: `0x${string}`[]
-    }[]
-    status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
-    blockHash: `0x${string}`
-    blockNumber: `0x${string}`
-    gasUsed: `0x${string}`
-    transactionHash: `0x${string}`
-  }[]
+  receipts?: CallReceipt[]
 }
 
 // supportedEIP5792Capabilities object
 export const supportedEIP5792CapabilitiesForEOA: GetCapabilitiesResult = {
-  // Not supporting any capabilities for now on EOA account
+  '0xaa36a7': {
+    atomicBatch: {
+      supported: true
+    }
+  }
 }
 // supportedEIP5792Capabilities object
 export const supportedEIP5792CapabilitiesForSCA: GetCapabilitiesResult = {

--- a/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
@@ -78,18 +78,6 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
           })
 
         case EIP5792_METHODS.WALLET_SEND_CALLS: {
-          const wallet = await getWallet(params)
-          if (wallet instanceof EIP155Lib) {
-            /**
-             * Not Supporting for batch calls on EOA for now.
-             * if EOA, we can submit call one by one, but need to have a data structure
-             * to return bundle id, for all the calls,
-             */
-            return await web3wallet.respondSessionRequest({
-              topic,
-              response: formatJsonRpcError(id, "Wallet currently don't support batch call for EOA")
-            })
-          }
           return ModalStore.open('SessionSendCallsModal', { requestEvent, requestSession })
         }
 

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP5792WalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP5792WalletUtil.ts
@@ -1,9 +1,32 @@
 import { eip155Addresses } from './EIP155WalletUtil'
 import {
+  CallReceipt,
+  GetCallsParams,
+  GetCallsResult,
   GetCapabilitiesResult,
+  SendCallsParams,
   supportedEIP5792CapabilitiesForEOA,
   supportedEIP5792CapabilitiesForSCA
 } from '@/data/EIP5792Data'
+import { randomBytes } from 'crypto'
+import { Wallet, ethers } from 'ethers'
+import {
+  ENTRYPOINT_ADDRESS_V06,
+  GetUserOperationReceiptReturnType,
+  createBundlerClient
+} from 'permissionless'
+import { Address, Hex, http, keccak256, toHex } from 'viem'
+
+type BatchTransactionsLog = {
+  calls: {
+    to: Address
+    value: bigint
+    data: Hex
+  }[]
+  callReceipts: CallReceipt[]
+}
+
+export const EIP5792_BATCH_TXS_STORAGE_KEY: string = 'EIP5792_BATCH_TXS'
 
 export function getWalletCapabilities(addresses: string[]) {
   const walletCapabilities: GetCapabilitiesResult = {}
@@ -12,11 +35,169 @@ export function getWalletCapabilities(addresses: string[]) {
     // address will be the last index element whether
     // its a simple address or namespace:chainId:address
     const addr = namespacesAddress[namespacesAddress.length - 1]
-    if (eip155Addresses.includes(addr)) {
-      // no capabilities support for EOA for now.
-      return
-    }
-    walletCapabilities[addr] = supportedEIP5792CapabilitiesForSCA
+
+    // Determine the capabilities based on the address type
+    const capabilities = eip155Addresses.includes(addr)
+      ? supportedEIP5792CapabilitiesForEOA
+      : supportedEIP5792CapabilitiesForSCA
+
+    // Assign the capabilities to the address
+    walletCapabilities[addr] = capabilities
   })
   return walletCapabilities
+}
+
+export const getCallsStatus = async (getCallParams: GetCallsParams) => {
+  // First search batchTxId locally if not found checking with bundler
+
+  const receiptFromLocal = getCallsReceiptFromLocal(getCallParams)
+  if (receiptFromLocal != null) return receiptFromLocal
+
+  /**
+   * Not maintaining the data for calls bundled for SCW right now.
+   * Getting directly from bundler the receipt on sepolia chain.
+   */
+  const apiKey = process.env.NEXT_PUBLIC_PIMLICO_KEY
+  const bundlerClient = createBundlerClient({
+    entryPoint: ENTRYPOINT_ADDRESS_V06,
+    transport: http(`https://api.pimlico.io/v1/sepolia/rpc?apikey=${apiKey}`)
+  })
+  const userOpReceipt = (await bundlerClient.getUserOperationReceipt({
+    hash: getCallParams as `0x${string}`
+  })) as GetUserOperationReceiptReturnType | null
+  const receiptFromBundler: GetCallsResult = {
+    status: userOpReceipt ? 'CONFIRMED' : 'PENDING',
+    receipts: userOpReceipt
+      ? [
+          {
+            logs: userOpReceipt.logs.map(log => ({
+              data: log.data,
+              address: log.address,
+              topics: log.topics
+            })),
+            blockHash: userOpReceipt.receipt.blockHash,
+            blockNumber: toHex(userOpReceipt.receipt.blockNumber),
+            gasUsed: toHex(userOpReceipt.actualGasUsed),
+            transactionHash: userOpReceipt.receipt.transactionHash,
+            status: userOpReceipt.success ? '0x1' : '0x0'
+          }
+        ]
+      : undefined
+  }
+  return receiptFromBundler
+}
+
+export const getSendCallData = (sendCallParams: SendCallsParams) => {
+  return sendCallParams.calls.map(call => ({
+    to: call.to,
+    value: BigInt(call.value || 0),
+    data: call.data || '0x'
+  }))
+}
+
+export async function sendBatchTransactionWithEOA(
+  wallet: Wallet,
+  args: {
+    to: Address
+    value: bigint
+    data: Hex
+  }[]
+) {
+  const newBatchTx: BatchTransactionsLog = { calls: args, callReceipts: [] }
+  const batchId = getBatchId()
+
+  let allBatchTxsData: Map<string, BatchTransactionsLog> = new Map()
+  const storedBatchTxsData = localStorage.getItem(EIP5792_BATCH_TXS_STORAGE_KEY)
+  if (storedBatchTxsData) {
+    const batchTxLogsArray = JSON.parse(storedBatchTxsData) as [string, BatchTransactionsLog][]
+    allBatchTxsData = new Map(batchTxLogsArray)
+  }
+
+  allBatchTxsData.set(batchId, newBatchTx)
+  localStorage.setItem(
+    EIP5792_BATCH_TXS_STORAGE_KEY,
+    JSON.stringify(Array.from(allBatchTxsData.entries()))
+  )
+
+  executeBatchCalls(wallet, batchId, args)
+
+  return batchId
+}
+
+async function executeBatchCalls(
+  wallet: Wallet,
+  batchId: string,
+  calls: {
+    to: Address
+    value: bigint
+    data: Hex
+  }[]
+) {
+  const callReceipts: CallReceipt[] = []
+
+  for (let index = 0; index < calls.length; index++) {
+    const call = calls[index]
+
+    const txResponse = await wallet.sendTransaction(call)
+    // Execute the call after a 1.5-second delay
+    await new Promise(resolve => setTimeout(resolve, 1500))
+    const txReceipt = await txResponse.wait()
+
+    const callReceipt: CallReceipt = {
+      logs: txReceipt.logs.map(log => ({
+        data: log.data as `0x${string}`,
+        address: log.address as `0x${string}`,
+        topics: log.topics as `0x${string}`[]
+      })),
+      blockHash: txReceipt.blockHash as `0x${string}`,
+      blockNumber: toHex(txReceipt.blockNumber),
+      gasUsed: toHex(txReceipt.cumulativeGasUsed.toString()),
+      transactionHash: txReceipt.transactionHash as `0x${string}`,
+      status: txReceipt.status ? '0x1' : '0x0'
+    }
+
+    callReceipts.push(callReceipt)
+  }
+
+  const newBatchTxs: BatchTransactionsLog = { calls: calls, callReceipts: callReceipts }
+  const storedBatchTxLogs = localStorage.getItem(EIP5792_BATCH_TXS_STORAGE_KEY)
+  let allBatchTxLogs: Map<string, BatchTransactionsLog> = new Map()
+
+  if (storedBatchTxLogs) {
+    const batchTxLogsArray = JSON.parse(storedBatchTxLogs) as [string, BatchTransactionsLog][]
+    allBatchTxLogs = new Map(batchTxLogsArray)
+  }
+
+  allBatchTxLogs.set(batchId, newBatchTxs)
+  localStorage.setItem(
+    EIP5792_BATCH_TXS_STORAGE_KEY,
+    JSON.stringify(Array.from(allBatchTxLogs.entries()))
+  )
+}
+
+async function getCallsReceiptFromLocal(
+  getCallParams: GetCallsParams
+): Promise<GetCallsResult | null> {
+  const storedBatchTxsData = localStorage.getItem(EIP5792_BATCH_TXS_STORAGE_KEY)
+  if (!storedBatchTxsData) return null
+
+  const allBatchTxsData = new Map(
+    JSON.parse(storedBatchTxsData) as [string, BatchTransactionsLog][]
+  )
+  const batchTxData = allBatchTxsData.get(getCallParams)
+  if (!batchTxData || !batchTxData.calls) return null
+
+  const { calls, callReceipts } = batchTxData
+  if (callReceipts === undefined || calls.length !== callReceipts.length) {
+    return { status: 'PENDING' }
+  }
+
+  return { status: 'CONFIRMED', receipts: callReceipts }
+}
+
+function getBatchId() {
+  const timestamp = Date.now()
+  return keccak256(
+    ethers.utils.concat([ethers.utils.arrayify(randomBytes(32)), ethers.utils.arrayify(timestamp)])
+  )
 }


### PR DESCRIPTION
For EOA's added support of EIP5792 method wallet_sendCalls.
Data related to call's and its receipts are stored on browser local browser storage.
Configured support on chain: sepolia