### PR TITLE
fix wallet reload on smart account toggle

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
@@ -1,3 +1,10 @@
+import { createOrRestoreEIP155Wallet } from '@/utils/EIP155WalletUtil'
+import {
+  createOrRestoreBiconomySmartAccount,
+  createOrRestoreKernelSmartAccount,
+  createOrRestoreSafeSmartAccount,
+  removeSmartAccount
+} from '@/utils/SmartAccountUtil'
 import { Verify, SessionTypes } from '@walletconnect/types'
 import { proxy } from 'valtio'
 
@@ -172,29 +179,50 @@ const SettingsStore = {
     }
   },
 
-  toggleKernelSmartAccountsEnabled() {
+  async toggleKernelSmartAccountsEnabled() {
     state.kernelSmartAccountEnabled = !state.kernelSmartAccountEnabled
     if (state.kernelSmartAccountEnabled) {
+      const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const { kernelSmartAccountAddress } = await createOrRestoreKernelSmartAccount(
+        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+      )
+      SettingsStore.setKernelSmartAccountAddress(kernelSmartAccountAddress)
       localStorage.setItem(ZERO_DEV_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
+      removeSmartAccount(SettingsStore.state.kernelSmartAccountAddress)
+      SettingsStore.setKernelSmartAccountAddress('')
       localStorage.removeItem(ZERO_DEV_SMART_ACCOUNTS_ENABLED_KEY)
     }
   },
 
-  toggleSafeSmartAccountsEnabled() {
+  async toggleSafeSmartAccountsEnabled() {
     state.safeSmartAccountEnabled = !state.safeSmartAccountEnabled
     if (state.safeSmartAccountEnabled) {
+      const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const { safeSmartAccountAddress } = await createOrRestoreSafeSmartAccount(
+        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+      )
+      SettingsStore.setSafeSmartAccountAddress(safeSmartAccountAddress)
       localStorage.setItem(SAFE_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
+      removeSmartAccount(SettingsStore.state.safeSmartAccountAddress)
+      SettingsStore.setSafeSmartAccountAddress('')
       localStorage.removeItem(SAFE_SMART_ACCOUNTS_ENABLED_KEY)
     }
   },
 
-  toggleBiconomySmartAccountsEnabled() {
+  async toggleBiconomySmartAccountsEnabled() {
     state.biconomySmartAccountEnabled = !state.biconomySmartAccountEnabled
     if (state.biconomySmartAccountEnabled) {
+      const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const { biconomySmartAccountAddress } = await createOrRestoreBiconomySmartAccount(
+        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+      )
+      SettingsStore.setBiconomySmartAccountAddress(biconomySmartAccountAddress)
       localStorage.setItem(BICONOMY_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
+      removeSmartAccount(SettingsStore.state.biconomySmartAccountAddress)
+      SettingsStore.setBiconomySmartAccountAddress('')
       localStorage.removeItem(BICONOMY_SMART_ACCOUNTS_ENABLED_KEY)
     }
   }

--- a/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
@@ -120,6 +120,12 @@ export async function createOrRestoreSafeSmartAccount(privateKey: string) {
     safeSmartAccountAddress: address
   }
 }
+export function removeSmartAccount(address: string) {
+  const key = `${sepolia.id}:${address}`
+  if (smartAccountWallets[key]) {
+    delete smartAccountWallets[key]
+  }
+}
 
 export async function createOrRestoreBiconomySmartAccount(privateKey: string) {
   const lib = new BiconomySmartAccountLib({ privateKey, chain: sepolia, sponsored: true })


### PR DESCRIPTION
This fix removes the requirement to reload the wallet after Smart account is enabled/toggled. Now the state is updated without reload.