### PR TITLE
Enable local AA infra support on sample wallet

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/consts/smartAccounts.ts
+++ b/advanced/wallets/react-wallet-v2/src/consts/smartAccounts.ts
@@ -1,9 +1,9 @@
 import { KernelSmartAccountLib } from '@/lib/smart-accounts/KernelSmartAccountLib'
 import { SafeSmartAccountLib } from '@/lib/smart-accounts/SafeSmartAccountLib'
-import { goerli, polygonMumbai, sepolia } from 'viem/chains'
+import { foundry, goerli, polygonMumbai, sepolia } from 'viem/chains'
 
 // Types
-export const allowedChains = [sepolia, polygonMumbai, goerli]
+export const allowedChains = [sepolia, polygonMumbai, goerli, foundry]
 // build chains so I can access them by id
 export const chains = allowedChains.reduce((acc, chain) => {
   acc[chain.id] = chain

--- a/advanced/wallets/react-wallet-v2/src/data/EIP155Data.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/EIP155Data.ts
@@ -115,6 +115,15 @@ export const EIP155_TEST_CHAINS: Record<string, EIP155Chain> = {
     rgb: '242, 242, 242',
     rpc: 'https://testnet.era.zksync.dev/',
     namespace: 'eip155'
+  },
+  'eip155:31337': {
+    chainId: 31337,
+    name: 'Foundry Testnet',
+    logo: '/chain-logos/eip155-1.png',
+    rgb: '242, 242, 242',
+    rpc: 'https://localhost:8545/',
+    namespace: 'eip155',
+    smartAccountEnabled: true
   }
 }
 

--- a/advanced/wallets/react-wallet-v2/src/data/EIP5792Data.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/EIP5792Data.ts
@@ -67,5 +67,11 @@ export const supportedEIP5792CapabilitiesForSCA: GetCapabilitiesResult = {
     atomicBatch: {
       supported: true
     }
+  },
+  // foundry chain
+  '0x7a69': {
+    atomicBatch: {
+      supported: true
+    }
   }
 }

--- a/advanced/wallets/react-wallet-v2/src/hooks/useSmartAccounts.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useSmartAccounts.ts
@@ -7,28 +7,35 @@ import {
 } from '@/utils/SmartAccountUtil'
 
 import { useSnapshot } from 'valtio'
+import { foundry, sepolia } from 'viem/chains'
 
 export default function useSmartAccounts() {
   const {
     smartAccountEnabled,
     kernelSmartAccountEnabled,
     safeSmartAccountEnabled,
-    biconomySmartAccountEnabled
+    biconomySmartAccountEnabled,
+    localAAInfraEnabled
   } = useSnapshot(SettingsStore.state)
 
   const initializeSmartAccounts = async (privateKey: string) => {
+    const chain = localAAInfraEnabled ? foundry : sepolia
     if (smartAccountEnabled) {
       if (kernelSmartAccountEnabled) {
-        const { kernelSmartAccountAddress } = await createOrRestoreKernelSmartAccount(privateKey)
+        const { kernelSmartAccountAddress } = await createOrRestoreKernelSmartAccount(
+          privateKey,
+          chain
+        )
         SettingsStore.setKernelSmartAccountAddress(kernelSmartAccountAddress)
       }
       if (safeSmartAccountEnabled) {
-        const { safeSmartAccountAddress } = await createOrRestoreSafeSmartAccount(privateKey)
+        const { safeSmartAccountAddress } = await createOrRestoreSafeSmartAccount(privateKey, chain)
         SettingsStore.setSafeSmartAccountAddress(safeSmartAccountAddress)
       }
       if (biconomySmartAccountEnabled) {
         const { biconomySmartAccountAddress } = await createOrRestoreBiconomySmartAccount(
-          privateKey
+          privateKey,
+          chain
         )
         SettingsStore.setBiconomySmartAccountAddress(biconomySmartAccountAddress)
       }

--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/KernelSmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/KernelSmartAccountLib.ts
@@ -32,7 +32,6 @@ import {
   createZeroDevPaymasterClient,
   KernelAccountClient
 } from '@zerodev/sdk'
-import { sepolia } from 'viem/chains'
 import { serializeSessionKeyAccount, signerToSessionKeyValidator } from '@zerodev/session-key'
 import { getUpdateConfigCall } from '@zerodev/weighted-ecdsa-validator'
 import {
@@ -133,13 +132,13 @@ export class KernelSmartAccountLib implements EIP155Wallet {
     })
     const client = createKernelAccountClient({
       account,
-      chain: sepolia,
+      chain: this.chain,
       entryPoint: this.entryPoint,
       bundlerTransport: bundlerRpc,
       middleware: {
         sponsorUserOperation: async ({ userOperation }) => {
           const zerodevPaymaster = createZeroDevPaymasterClient({
-            chain: sepolia,
+            chain: this.chain,
             entryPoint: this.entryPoint,
             // Get this RPC from ZeroDev dashboard
             transport: http(`https://rpc.zerodev.app/api/v2/paymaster/${projectId}`)

--- a/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
@@ -28,7 +28,8 @@ export default function SettingsPage() {
     kernelSmartAccountEnabled,
     safeSmartAccountEnabled,
     biconomySmartAccountEnabled,
-    moduleManagementEnabled
+    moduleManagementEnabled,
+    localAAInfraEnabled
   } = useSnapshot(SettingsStore.state)
 
   return (
@@ -140,6 +141,23 @@ export default function SettingsPage() {
                       data-testid="settings-toggle-module-management"
                     />
                     <Text>{moduleManagementEnabled ? 'Enabled' : 'Disabled'}</Text>
+                  </Row>
+                  <Divider y={2} />
+                  <Text h4 css={{ marginBottom: '$5', cursor: 'pointer' }}>
+                    Local AA Infra
+                  </Text>
+                  <Row justify="space-between" align="center">
+                    <Switch
+                      disabled={
+                        !kernelSmartAccountEnabled &&
+                        !safeSmartAccountEnabled &&
+                        !biconomySmartAccountEnabled
+                      }
+                      checked={localAAInfraEnabled}
+                      onChange={SettingsStore.toggleLocalAAInfra}
+                      data-testid="settings-toggle-local-aa-infra"
+                    />
+                    <Text>{localAAInfraEnabled ? 'Enabled' : 'Disabled'}</Text>
                   </Row>
                 </>
               ) : null}

--- a/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
@@ -7,6 +7,7 @@ import {
 } from '@/utils/SmartAccountUtil'
 import { Verify, SessionTypes } from '@walletconnect/types'
 import { proxy } from 'valtio'
+import { foundry, sepolia } from 'viem/chains'
 
 const TEST_NETS_ENABLED_KEY = 'TEST_NETS'
 const SMART_ACCOUNTS_ENABLED_KEY = 'SMART_ACCOUNTS'
@@ -198,26 +199,73 @@ const SettingsStore = {
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)
     }
   },
-  toggleLocalAAInfra() {
+  async toggleLocalAAInfra() {
     state.localAAInfraEnabled = !state.localAAInfraEnabled
+
+    // Update local storage based on the state
     if (state.localAAInfraEnabled) {
       localStorage.setItem(LOCAL_AA_INFRA_ENABLED_KEY, 'YES')
     } else {
       localStorage.removeItem(LOCAL_AA_INFRA_ENABLED_KEY)
     }
+    // Define account types with corresponding properties
+    const accountTypes = [
+      {
+        enabled: state.safeSmartAccountEnabled,
+        address: SettingsStore.state.safeSmartAccountAddress,
+        createOrRestore: createOrRestoreSafeSmartAccount,
+        setter: SettingsStore.setSafeSmartAccountAddress
+      },
+      {
+        enabled: state.kernelSmartAccountEnabled,
+        address: SettingsStore.state.kernelSmartAccountAddress,
+        createOrRestore: createOrRestoreKernelSmartAccount,
+        setter: SettingsStore.setKernelSmartAccountAddress
+      },
+      {
+        enabled: state.biconomySmartAccountEnabled,
+        address: SettingsStore.state.biconomySmartAccountAddress,
+        createOrRestore: createOrRestoreBiconomySmartAccount,
+        setter: SettingsStore.setBiconomySmartAccountAddress
+      }
+    ]
+
+    // Create or restore EIP-155 wallet
+    const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+    const privateKey = eip155Wallets[eip155Addresses[0]].getPrivateKey()
+    const newChain = state.localAAInfraEnabled ? foundry : sepolia
+    const oldChain = state.localAAInfraEnabled ? sepolia : foundry
+
+    // Process account types concurrently
+    await Promise.all(
+      accountTypes.map(async account => {
+        // Remove smart account from the old chain
+        removeSmartAccount(account.address, oldChain)
+
+        if (account.enabled) {
+          // Create or restore account on the new chain
+          const result = await account.createOrRestore(privateKey, newChain)
+          const [newAddress] = Object.values(result)
+          account.setter(newAddress)
+        }
+      })
+    )
   },
 
   async toggleKernelSmartAccountsEnabled() {
     state.kernelSmartAccountEnabled = !state.kernelSmartAccountEnabled
     if (state.kernelSmartAccountEnabled) {
       const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
       const { kernelSmartAccountAddress } = await createOrRestoreKernelSmartAccount(
-        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+        eip155Wallets[eip155Addresses[0]].getPrivateKey(),
+        chain
       )
       SettingsStore.setKernelSmartAccountAddress(kernelSmartAccountAddress)
       localStorage.setItem(ZERO_DEV_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
-      removeSmartAccount(SettingsStore.state.kernelSmartAccountAddress)
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
+      removeSmartAccount(SettingsStore.state.kernelSmartAccountAddress, chain)
       SettingsStore.setKernelSmartAccountAddress('')
       state.moduleManagementEnabled = false
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)
@@ -229,13 +277,16 @@ const SettingsStore = {
     state.safeSmartAccountEnabled = !state.safeSmartAccountEnabled
     if (state.safeSmartAccountEnabled) {
       const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
       const { safeSmartAccountAddress } = await createOrRestoreSafeSmartAccount(
-        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+        eip155Wallets[eip155Addresses[0]].getPrivateKey(),
+        chain
       )
       SettingsStore.setSafeSmartAccountAddress(safeSmartAccountAddress)
       localStorage.setItem(SAFE_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
-      removeSmartAccount(SettingsStore.state.safeSmartAccountAddress)
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
+      removeSmartAccount(SettingsStore.state.safeSmartAccountAddress, chain)
       SettingsStore.setSafeSmartAccountAddress('')
       state.moduleManagementEnabled = false
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)
@@ -247,13 +298,16 @@ const SettingsStore = {
     state.biconomySmartAccountEnabled = !state.biconomySmartAccountEnabled
     if (state.biconomySmartAccountEnabled) {
       const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
       const { biconomySmartAccountAddress } = await createOrRestoreBiconomySmartAccount(
-        eip155Wallets[eip155Addresses[0]].getPrivateKey()
+        eip155Wallets[eip155Addresses[0]].getPrivateKey(),
+        chain
       )
       SettingsStore.setBiconomySmartAccountAddress(biconomySmartAccountAddress)
       localStorage.setItem(BICONOMY_SMART_ACCOUNTS_ENABLED_KEY, 'YES')
     } else {
-      removeSmartAccount(SettingsStore.state.biconomySmartAccountAddress)
+      const chain = state.localAAInfraEnabled ? foundry : sepolia
+      removeSmartAccount(SettingsStore.state.biconomySmartAccountAddress, chain)
       SettingsStore.setBiconomySmartAccountAddress('')
       state.moduleManagementEnabled = false
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)

--- a/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
@@ -14,6 +14,7 @@ const ZERO_DEV_SMART_ACCOUNTS_ENABLED_KEY = 'ZERO_DEV_SMART_ACCOUNTS'
 const SAFE_SMART_ACCOUNTS_ENABLED_KEY = 'SAFE_SMART_ACCOUNTS'
 const BICONOMY_SMART_ACCOUNTS_ENABLED_KEY = 'BICONOMY_SMART_ACCOUNTS'
 const MODULE_MANAGEMENT_ENABLED_KEY = 'MODULE_MANAGEMENT'
+const LOCAL_AA_INFRA_ENABLED_KEY = 'LOCAL_AA_INFRA'
 
 /**
  * Types
@@ -43,6 +44,7 @@ interface State {
   safeSmartAccountEnabled: boolean
   biconomySmartAccountEnabled: boolean
   moduleManagementEnabled: boolean
+  localAAInfraEnabled: boolean
 }
 
 /**
@@ -89,6 +91,10 @@ const state = proxy<State>({
   moduleManagementEnabled:
     typeof localStorage !== 'undefined'
       ? Boolean(localStorage.getItem(MODULE_MANAGEMENT_ENABLED_KEY))
+      : false,
+  localAAInfraEnabled:
+    typeof localStorage !== 'undefined'
+      ? Boolean(localStorage.getItem(LOCAL_AA_INFRA_ENABLED_KEY))
       : false
 })
 
@@ -190,6 +196,14 @@ const SettingsStore = {
       localStorage.setItem(MODULE_MANAGEMENT_ENABLED_KEY, 'YES')
     } else {
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)
+    }
+  },
+  toggleLocalAAInfra() {
+    state.localAAInfraEnabled = !state.localAAInfraEnabled
+    if (state.localAAInfraEnabled) {
+      localStorage.setItem(LOCAL_AA_INFRA_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(LOCAL_AA_INFRA_ENABLED_KEY)
     }
   },
 

--- a/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
@@ -41,7 +41,7 @@ export const RPC_URLS: Record<Chain['name'], string> = {
   Sepolia: 'https://rpc.ankr.com/eth_sepolia',
   'Polygon Mumbai': 'https://mumbai.rpc.thirdweb.com',
   Goerli: 'https://ethereum-goerli.publicnode.com',
-  Foundry: 'http://localhost:8545/'
+  Foundry: 'http://localhost:8545'
 }
 
 // Pimlico RPC names

--- a/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SmartAccountUtil.ts
@@ -3,7 +3,7 @@ import { Hex } from 'viem'
 import { SessionTypes } from '@walletconnect/types'
 import { Chain, allowedChains } from '@/consts/smartAccounts'
 import { KernelSmartAccountLib } from '@/lib/smart-accounts/KernelSmartAccountLib'
-import { sepolia } from 'viem/chains'
+import { foundry, sepolia } from 'viem/chains'
 import { SafeSmartAccountLib } from '@/lib/smart-accounts/SafeSmartAccountLib'
 import { SmartAccountLib } from '@/lib/smart-accounts/SmartAccountLib'
 
@@ -15,7 +15,8 @@ export type UrlConfig = {
 export const ENTRYPOINT_ADDRESSES: Record<Chain['name'], Hex> = {
   Sepolia: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
   'Polygon Mumbai': '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
-  Goerli: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
+  Goerli: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+  Foundry: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
 }
 
 // Paymasters
@@ -23,28 +24,32 @@ export const ENTRYPOINT_ADDRESSES: Record<Chain['name'], Hex> = {
 export const PAYMASTER_ADDRESSES: Record<Chain['name'], Hex> = {
   Sepolia: '0x0000000000325602a77416A16136FDafd04b299f',
   'Polygon Mumbai': '0x000000000009B901DeC1aaB9389285965F49D387',
-  Goerli: '0xEc43912D8C772A0Eba5a27ea5804Ba14ab502009'
+  Goerli: '0xEc43912D8C772A0Eba5a27ea5804Ba14ab502009',
+  Foundry: '0x0000000000325602a77416A16136FDafd04b299f'
 }
 
 // USDC
 export const USDC_ADDRESSES: Record<Chain['name'], Hex> = {
   Sepolia: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
   'Polygon Mumbai': '0x9999f7fea5938fd3b1e26a12c3f2fb024e194f97',
-  Goerli: '0x07865c6e87b9f70255377e024ace6630c1eaa37f'
+  Goerli: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
+  Foundry: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 }
 
 // RPC URLs
 export const RPC_URLS: Record<Chain['name'], string> = {
   Sepolia: 'https://rpc.ankr.com/eth_sepolia',
   'Polygon Mumbai': 'https://mumbai.rpc.thirdweb.com',
-  Goerli: 'https://ethereum-goerli.publicnode.com'
+  Goerli: 'https://ethereum-goerli.publicnode.com',
+  Foundry: 'http://localhost:8545/'
 }
 
 // Pimlico RPC names
 export const PIMLICO_NETWORK_NAMES: Record<Chain['name'], string> = {
   Sepolia: 'sepolia',
   'Polygon Mumbai': 'mumbai',
-  Goerli: 'goerli'
+  Goerli: 'goerli',
+  Foundry: 'foundry'
 }
 
 export const publicRPCUrl = ({ chain }: UrlConfig) => {
@@ -76,9 +81,9 @@ export function supportedAddressPriority(
   return []
 }
 
-export const kernelAllowedChains = [sepolia]
-export const safeAllowedChains = [sepolia]
-export const biconomyAllowedChains = [sepolia]
+export const kernelAllowedChains = [sepolia, foundry]
+export const safeAllowedChains = [sepolia, foundry]
+export const biconomyAllowedChains = [sepolia, foundry]
 
 export let smartAccountWallets: Record<string, SmartAccountLib | KernelSmartAccountLib> = {}
 
@@ -86,16 +91,19 @@ export function isAllowedKernelChain(chainId: number): boolean {
   return kernelAllowedChains.some(chain => chain.id == chainId)
 }
 
-export async function createOrRestoreKernelSmartAccount(privateKey: string) {
+export async function createOrRestoreKernelSmartAccount(
+  privateKey: string,
+  chain: Chain = sepolia
+) {
   const lib = new KernelSmartAccountLib({
     privateKey,
-    chain: sepolia,
+    chain: chain,
     sponsored: true,
     entryPointVersion: 6
   })
   await lib.init()
   const address = lib.getAddress()
-  const key = `${sepolia.id}:${address}`
+  const key = `${chain.id}:${address}`
   if (!smartAccountWallets[key]) {
     smartAccountWallets[key] = lib
   }
@@ -108,16 +116,16 @@ export function isAllowedSafeChain(chainId: number): boolean {
   return safeAllowedChains.some(chain => chain.id == chainId)
 }
 
-export async function createOrRestoreSafeSmartAccount(privateKey: string) {
+export async function createOrRestoreSafeSmartAccount(privateKey: string, chain: Chain = sepolia) {
   const lib = new SafeSmartAccountLib({
     privateKey,
-    chain: sepolia,
+    chain: chain,
     sponsored: true,
     entryPointVersion: 7
   })
   await lib.init()
   const address = lib.getAddress()
-  const key = `${sepolia.id}:${address}`
+  const key = `${chain.id}:${address}`
   if (!smartAccountWallets[key]) {
     smartAccountWallets[key] = lib
   }
@@ -125,18 +133,21 @@ export async function createOrRestoreSafeSmartAccount(privateKey: string) {
     safeSmartAccountAddress: address
   }
 }
-export function removeSmartAccount(address: string) {
-  const key = `${sepolia.id}:${address}`
+export function removeSmartAccount(address: string, chain: Chain = sepolia) {
+  const key = `${chain.id}:${address}`
   if (smartAccountWallets[key]) {
     delete smartAccountWallets[key]
   }
 }
 
-export async function createOrRestoreBiconomySmartAccount(privateKey: string) {
-  const lib = new BiconomySmartAccountLib({ privateKey, chain: sepolia, sponsored: true })
+export async function createOrRestoreBiconomySmartAccount(
+  privateKey: string,
+  chain: Chain = sepolia
+) {
+  const lib = new BiconomySmartAccountLib({ privateKey, chain: chain, sponsored: true })
   await lib.init()
   const address = lib.getAddress()
-  const key = `${sepolia.id}:${address}`
+  const key = `${chain.id}:${address}`
   if (!smartAccountWallets[key]) {
     smartAccountWallets[key] = lib
   }


### PR DESCRIPTION
1. Added switch for enabling local AA infra setup for sample wallet
<img width="175" height="350" src="https://github.com/WalletConnect/web-examples/assets/90941366/d94b5de6-2fc9-4ce0-ad5b-624d7556a327">

The local AA infra can be run using this guide, it assumes default URLs for bundler,paymasters and publicRPC from this guide
https://docs.pimlico.io/permissionless/how-to/local-testing 

Closes RES-13