### PR TITLE
fix: sendTransaction arg type

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SafeSmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SafeSmartAccountLib.ts
@@ -56,13 +56,13 @@ export class SafeSmartAccountLib extends SmartAccountLib {
     }
   }
 
-  async sendTransaction({ to, value, data }: { to: Address; value: bigint; data: Hex }) {
+  async sendTransaction({ to, value, data }: { to: Address; value: bigint | Hex; data: Hex }) {
     if (!this.client?.account) {
       throw new Error('Client not initialized')
     }
     const txResult = await this.client.sendTransaction({
       to,
-      value,
+      value: BigInt(value),
       data,
       account: this.client.account,
       chain: this.chain

--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
@@ -200,13 +200,13 @@ export abstract class SmartAccountLib implements EIP155Wallet {
     const signature = await this.client.account.signTransaction(transaction)
     return signature || ''
   }
-  async sendTransaction({ to, value, data }: { to: Address; value: bigint; data: Hex }) {
+  async sendTransaction({ to, value, data }: { to: Address; value: bigint | Hex; data: Hex }) {
     if (!this.client || !this.client.account) {
       throw new Error('Client not initialized')
     }
     const txResult = await this.client.sendTransaction({
       to,
-      value,
+      value: BigInt(value),
       data,
       account: this.client.account,
       chain: this.chain


### PR DESCRIPTION
Changed function argument to handle Hex data for `value` field on `SafeSmartAccountLib.ts` and `SmartAccountLib.ts`. 
`sendTransaction({ to, value, data }: { to: Address; value: bigint; data: Hex })` to
`sendTransaction({ to, value, data }: { to: Address; value: bigint | Hex; data: Hex })`