### PR TITLE
fix(gha): run against ui_tests.yml@main, do not run on unrelated PR diffs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -14,8 +14,9 @@ env:
 
 on:
   pull_request:
-    branches:
-      - main
+    paths:
+      - "advanced/wallets/react-wallet-v2/**"
+      - "advanced/dapps/react-dapp-v2/**"
 
 jobs:
   code_style:

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -32,9 +32,9 @@ jobs:
       base-url: http://localhost:3000/
       wallet-url: ${{ needs.preview.outputs.preview-url }}/
       skip-playwright-webserver: false
-      branch: V4
+      branch: main
       command: playwright:test:wallet
-    uses: WalletConnect/web3modal/.github/workflows/ui_tests.yml@V4
+    uses: WalletConnect/web3modal/.github/workflows/ui_tests.yml@main
     secrets:
       NEXT_PUBLIC_PROJECT_ID: ${{ secrets.UI_TEST_PROJECT_ID }}
       TESTS_NEXTAUTH_SECRET: ${{ secrets.TESTS_NEXTAUTH_SECRET }}


### PR DESCRIPTION
## Description

- Ensure that the `ui_tests` workflow runs against W3M `main` (it was still pointed at the `V4` branch)
- Do not run PR checks on unrelated diffs (i.e. anything not modifying `react-wallet-v2` or `react-dapp-v2`)
- Not seen here: removed the style check and UI test jobs from being required in the repo settings so we don't hang on `Expected - Waiting for status to be reported`