### PR TITLE
fix: refreshes session list when `/sessions` route is loaded

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
@@ -20,6 +20,7 @@ import { approveEIP5792Request } from '@/utils/EIP5792RequestHandlerUtils'
 import EIP155Lib from '@/lib/EIP155Lib'
 import { getWallet } from '@/utils/EIP155WalletUtil'
 import { EIP7715_METHOD } from '@/data/EIP7715Data'
+import { refreshSessionsList } from '@/pages/wc'
 
 export default function useWalletConnectEventsManager(initialized: boolean) {
   /******************************************************************************
@@ -173,11 +174,11 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
       web3wallet.engine.signClient.events.on('session_ping', data => console.log('ping', data))
       web3wallet.on('session_delete', data => {
         console.log('session_delete event received', data)
-        SettingsStore.setSessions(Object.values(web3wallet.getActiveSessions()))
+        refreshSessionsList()
       })
       web3wallet.on('session_authenticate', onSessionAuthenticate)
       // load sessions on init
-      SettingsStore.setSessions(Object.values(web3wallet.getActiveSessions()))
+      refreshSessionsList()
     }
-  }, [initialized, onAuthRequest, onSessionProposal, onSessionRequest])
+  }, [initialized, onAuthRequest, onSessionAuthenticate, onSessionProposal, onSessionRequest])
 }

--- a/advanced/wallets/react-wallet-v2/src/pages/sessions.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/sessions.tsx
@@ -2,12 +2,13 @@ import PageHeader from '@/components/PageHeader'
 import SessionCard from '@/components/SessionCard'
 import SettingsStore from '@/store/SettingsStore'
 import { Text } from '@nextui-org/react'
-import { Fragment } from 'react'
+import { Fragment, useEffect } from 'react'
 import { useSnapshot } from 'valtio'
+import { refreshSessionsList } from './wc'
 
 export default function SessionsPage() {
   const { sessions } = useSnapshot(SettingsStore.state)
-
+  useEffect(() => refreshSessionsList(), [])
   if (!sessions.length) {
     return (
       <Fragment>

--- a/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/router'
 import WalletConnectPage from './walletconnect'
 import ModalStore from '@/store/ModalStore'
 import { useSnapshot } from 'valtio'
+import SettingsStore from '@/store/SettingsStore'
+import { web3wallet } from '@/utils/WalletConnectUtil'
 
 export default function DeepLinkPairingPage() {
   const state = useSnapshot(ModalStore.state)
@@ -53,4 +55,9 @@ export default function DeepLinkPairingPage() {
   }
 
   return <WalletConnectPage deepLink={uri} />
+}
+
+export function refreshSessionsList() {
+  if (!web3wallet) return
+  SettingsStore.setSessions(Object.values(web3wallet.getActiveSessions()))
 }


### PR DESCRIPTION
- added refresh sessions list util
- force refresh session list when `/sessions` route is loaded

This resolves a bug when initiating disconnect from the wallet was incorrectly showing the session as active in the session list