### PR TITLE
fix: replces sign with web3wallet in text

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
@@ -39,7 +39,7 @@ export default function SettingsPage() {
         Packages
       </Text>
       <Row justify="space-between" align="center">
-        <Text color="$gray400">@walletconnect/sign-client</Text>
+        <Text color="$gray400">@walletconnect/web3wallet</Text>
         <Text color="$gray400">{packageJSON.dependencies['@walletconnect/web3wallet']}</Text>
       </Row>
 


### PR DESCRIPTION
text was incorrectly set to sign client but versioning points to web3wallet