### PR TITLE
feat: solana sign and send transaction

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/data/SolanaData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/SolanaData.ts
@@ -21,7 +21,7 @@ export const SOLANA_MAINNET_CHAINS = {
     name: 'Solana',
     logo: '/chain-logos/solana-5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp.png',
     rgb: '30, 240, 166',
-    rpc: '',
+    rpc: 'https://api.mainnet-beta.solana.com',
     namespace: 'solana'
   }
 }
@@ -41,7 +41,7 @@ export const SOLANA_TEST_CHAINS = {
     name: 'Solana Devnet',
     logo: '/chain-logos/solana-5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp.png',
     rgb: '30, 240, 166',
-    rpc: '',
+    rpc: 'https://api.devnet.solana.com',
     namespace: 'solana'
   },
   'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z': {
@@ -49,7 +49,7 @@ export const SOLANA_TEST_CHAINS = {
     name: 'Solana Testnet',
     logo: '/chain-logos/solana-5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp.png',
     rgb: '30, 240, 166',
-    rpc: '',
+    rpc: 'https://api.testnet.solana.com',
     namespace: 'solana'
   }
 }
@@ -61,5 +61,6 @@ export const SOLANA_CHAINS = { ...SOLANA_MAINNET_CHAINS, ...SOLANA_TEST_CHAINS }
  */
 export const SOLANA_SIGNING_METHODS = {
   SOLANA_SIGN_TRANSACTION: 'solana_signTransaction',
-  SOLANA_SIGN_MESSAGE: 'solana_signMessage'
+  SOLANA_SIGN_MESSAGE: 'solana_signMessage',
+  SOLANA_SIGN_AND_SEND_TRANSACTION: 'solana_signAndSendTransaction'
 }

--- a/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
@@ -106,6 +106,7 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
 
         case SOLANA_SIGNING_METHODS.SOLANA_SIGN_MESSAGE:
         case SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION:
+        case SOLANA_SIGNING_METHODS.SOLANA_SIGN_AND_SEND_TRANSACTION:
           return ModalStore.open('SessionSignSolanaModal', { requestEvent, requestSession })
 
         case POLKADOT_SIGNING_METHODS.POLKADOT_SIGN_MESSAGE:

--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -3,7 +3,8 @@ import {
   Connection,
   Transaction,
   TransactionInstruction,
-  PublicKey
+  PublicKey,
+  SendOptions
 } from '@solana/web3.js'
 import bs58 from 'bs58'
 import nacl from 'tweetnacl'
@@ -69,7 +70,8 @@ export default class SolanaLib {
   public async signAndSendTransaction(
     feePayer: SolanaSignTransaction['feePayer'],
     instructions: SolanaSignTransaction['instructions'],
-    chainId: string
+    chainId: string,
+    options: SendOptions = {}
   ) {
     const rpc = { ...SOLANA_TEST_CHAINS, ...SOLANA_MAINNET_CHAINS }[chainId]?.rpc
 
@@ -111,6 +113,11 @@ export default class SolanaLib {
     transaction.sign(this.keypair)
 
     const signature = await connection.sendRawTransaction(transaction.serialize())
+    const confirmation = await connection.confirmTransaction(signature, options.preflightCommitment)
+
+    if (confirmation.value.err) {
+      throw new Error(confirmation.value.err.toString())
+    }
 
     return { signature }
   }

--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -68,7 +68,6 @@ export default class SolanaLib {
 
   public async signAndSendTransaction(
     feePayer: SolanaSignTransaction['feePayer'],
-    recentBlockhash: SolanaSignTransaction['recentBlockhash'],
     instructions: SolanaSignTransaction['instructions'],
     chainId: string
   ) {
@@ -108,7 +107,7 @@ export default class SolanaLib {
 
     const transaction = new Transaction().add(...parsedInstructions)
     transaction.feePayer = new PublicKey(feePayer)
-    transaction.recentBlockhash = recentBlockhash
+    transaction.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
     transaction.sign(this.keypair)
 
     const signature = await connection.sendRawTransaction(transaction.serialize())

--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -88,17 +88,10 @@ export default class SolanaLib {
         isWritable: key.isWritable
       }))
       const programId = new PublicKey(instruction.programId)
-      const data = (() => {
-        if (typeof instruction.data === 'undefined') {
-          return undefined
-        }
-
-        if (typeof instruction.data === 'string') {
-          return Buffer.from(bs58.decode(instruction.data).buffer)
-        }
-
-        return instruction.data
-      })()
+      const data =
+        typeof instruction.data === 'string'
+          ? Buffer.from(bs58.decode(instruction.data).buffer)
+          : instruction.data
 
       return new TransactionInstruction({
         keys,

--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -1,7 +1,14 @@
-import { Keypair } from '@solana/web3.js'
+import {
+  Keypair,
+  Connection,
+  Transaction,
+  TransactionInstruction,
+  PublicKey
+} from '@solana/web3.js'
 import bs58 from 'bs58'
 import nacl from 'tweetnacl'
 import SolanaWallet, { SolanaSignTransaction } from 'solana-wallet'
+import { SOLANA_MAINNET_CHAINS, SOLANA_TEST_CHAINS } from '@/data/SolanaData'
 
 /**
  * Types
@@ -55,6 +62,56 @@ export default class SolanaLib {
       recentBlockhash,
       partialSignatures: partialSignatures ?? []
     })
+
+    return { signature }
+  }
+
+  public async signAndSendTransaction(
+    feePayer: SolanaSignTransaction['feePayer'],
+    recentBlockhash: SolanaSignTransaction['recentBlockhash'],
+    instructions: SolanaSignTransaction['instructions'],
+    chainId: string
+  ) {
+    const rpc = { ...SOLANA_TEST_CHAINS, ...SOLANA_MAINNET_CHAINS }[chainId]?.rpc
+
+    if (!rpc) {
+      throw new Error('There is no RPC URL for the provided chain')
+    }
+
+    const connection = new Connection(rpc)
+
+    const parsedInstructions = instructions.map(instruction => {
+      const keys = instruction.keys.map(key => ({
+        pubkey: new PublicKey(key.pubkey),
+        isSigner: key.isSigner,
+        isWritable: key.isWritable
+      }))
+      const programId = new PublicKey(instruction.programId)
+      const data = (() => {
+        if (typeof instruction.data === 'undefined') {
+          return undefined
+        }
+
+        if (typeof instruction.data === 'string') {
+          return Buffer.from(bs58.decode(instruction.data).buffer)
+        }
+
+        return instruction.data
+      })()
+
+      return new TransactionInstruction({
+        keys,
+        programId,
+        data
+      })
+    })
+
+    const transaction = new Transaction().add(...parsedInstructions)
+    transaction.feePayer = new PublicKey(feePayer)
+    transaction.recentBlockhash = recentBlockhash
+    transaction.sign(this.keypair)
+
+    const signature = await connection.sendRawTransaction(transaction.serialize())
 
     return { signature }
   }

--- a/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
@@ -9,7 +9,7 @@ export async function approveSolanaRequest(
   requestEvent: SignClientTypes.EventArguments['session_request']
 ) {
   const { params, id } = requestEvent
-  const { request } = params
+  const { request, chainId } = params
   const wallet = solanaWallets[getWalletAddressFromParams(solanaAddresses, params)]
 
   switch (request.method) {
@@ -25,6 +25,16 @@ export async function approveSolanaRequest(
       )
 
       return formatJsonRpcResult(id, signedTransaction)
+
+    case SOLANA_SIGNING_METHODS.SOLANA_SIGN_AND_SEND_TRANSACTION:
+      const signedAndSentTransaction = await wallet.signAndSendTransaction(
+        request.params.feePayer,
+        request.params.recentBlockhash,
+        request.params.instructions,
+        chainId
+      )
+
+      return formatJsonRpcResult(id, signedAndSentTransaction)
 
     default:
       throw new Error(getSdkError('INVALID_METHOD').message)

--- a/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
@@ -30,7 +30,8 @@ export async function approveSolanaRequest(
       const signedAndSentTransaction = await wallet.signAndSendTransaction(
         request.params.feePayer,
         request.params.instructions,
-        chainId
+        chainId,
+        request.params.options
       )
 
       return formatJsonRpcResult(id, signedAndSentTransaction)

--- a/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SolanaRequestHandlerUtil.ts
@@ -29,7 +29,6 @@ export async function approveSolanaRequest(
     case SOLANA_SIGNING_METHODS.SOLANA_SIGN_AND_SEND_TRANSACTION:
       const signedAndSentTransaction = await wallet.signAndSendTransaction(
         request.params.feePayer,
-        request.params.recentBlockhash,
         request.params.instructions,
         chainId
       )


### PR DESCRIPTION
# Description

This PR is adding `signAndSendTransaction` for Solana wallet by listening to `solana_signAndSendTransaction` RPC call.

https://github.com/user-attachments/assets/243b1597-3f00-484a-b3b5-dc1aa827390d

