### PR TITLE
chore: sets bundler name

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
@@ -6,7 +6,7 @@ export async function createWeb3Wallet(relayerRegionURL: string) {
   const core = new Core({
     projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
     relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAY_URL,
-    logger: 'trace'
+    logger: 'debug'
   })
   web3wallet = await Web3Wallet.init({
     core,

--- a/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
+++ b/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx
@@ -276,7 +276,10 @@ export default function SessionProposalModal() {
         }
         //get capabilities for all reorderedEip155Accounts in wallet
         const capabilities = getWalletCapabilities(reorderedEip155Accounts)
-        const sessionProperties = { capabilities: JSON.stringify(capabilities) }
+        const sessionProperties = {
+          capabilities: JSON.stringify(capabilities),
+          bundler_name: 'pimlico'
+        }
 
         await web3wallet.approveSession({
           id: proposal.id,


### PR DESCRIPTION
Sets bundler name in session properties to be used by the provider proxy to fetch batch calls status