### PR TITLE
fix: return userOpHash instead of txHash

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/builders/SafeUserOpBuilder.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/builders/SafeUserOpBuilder.ts
@@ -23,7 +23,6 @@ import {
   createSmartAccountClient,
   ENTRYPOINT_ADDRESS_V07,
   getAccountNonce,
-  getPackedUserOperation,
   getUserOperationHash
 } from 'permissionless'
 import {
@@ -172,12 +171,9 @@ export class SafeUserOpBuilder implements UserOpBuilder {
         maxPriorityFeePerGas: BigInt(userOp.maxPriorityFeePerGas)
       }
     })
-    const receipt = await pimlicoBundlerClient.waitForUserOperationReceipt({
-      hash: userOpHash
-    })
 
     return {
-      receipt: receipt.receipt.transactionHash
+      receipt: userOpHash
     }
   }
 


### PR DESCRIPTION
### Update: Returning `userOpHash` in `/sendUserOp` Endpoint Response

Due to a timeout issue on Vercel when waiting for transaction receipt (maximum wait time is 15 seconds), we are now returning the `userOpHash` in the response for the `/sendUserOp` endpoint.

For retrieving the receipt or transaction hash, it is recommended that the app use the [Blockchain Bundler API](https://specs.walletconnect.com/2.0/specs/servers/blockchain/blockchain-bundler-api).
