### PR TITLE
fix: solana broken examples

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -857,16 +857,22 @@ export function JsonRpcContextProvider({
             method: DEFAULT_SOLANA_METHODS.SOL_SIGN_TRANSACTION,
             params: {
               feePayer: transaction.feePayer!.toBase58(),
-              recentBlockhash: transaction.recentBlockhash,
-              instructions: transaction.instructions.map((i) => ({
-                programId: i.programId.toBase58(),
-                data: Array.from(i.data),
-                keys: i.keys.map((k) => ({
-                  isSigner: k.isSigner,
-                  isWritable: k.isWritable,
-                  pubkey: k.pubkey.toBase58(),
+              recentBlockhash: transaction.recentBlockhash!,
+              instructions: transaction.instructions.map((instruction) => ({
+                programId: instruction.programId.toBase58(),
+                keys: instruction.keys.map((key) => ({
+                  ...key,
+                  pubkey: key.pubkey.toBase58(),
                 })),
+                data: bs58.encode(instruction.data),
               })),
+              partialSignatures: transaction.signatures.map((sign) => ({
+                pubkey: sign.publicKey.toBase58(),
+                signature: bs58.encode(sign.signature!),
+              })),
+              transaction: transaction
+                .serialize({ verifySignatures: false })
+                .toString('base64'),
             },
           },
         });

--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -49,7 +49,10 @@ export default class SolanaLib {
     const transaction = this.deserialize(params.transaction)
     this.sign(transaction)
 
-    return { transaction: this.serialize(transaction) }
+    return {
+      transaction: this.serialize(transaction),
+      signature: bs58.encode(transaction.signatures[0])
+    }
   }
 
   public async signAndSendTransaction(
@@ -80,7 +83,14 @@ export default class SolanaLib {
   }
 
   private deserialize(transaction: string): VersionedTransaction {
-    return VersionedTransaction.deserialize(bs58.decode(transaction))
+    let bytes: Uint8Array
+    try {
+      bytes = bs58.decode(transaction)
+    } catch {
+      bytes = Buffer.from(transaction, 'base64')
+    }
+
+    return VersionedTransaction.deserialize(bytes)
   }
 
   private sign(transaction: VersionedTransaction) {
@@ -96,7 +106,10 @@ export namespace SolanaLib {
 
   export type SignMessage = RPCRequest<{ message: string }, { signature: string }>
 
-  export type SignTransaction = RPCRequest<{ transaction: string }, { transaction: string }>
+  export type SignTransaction = RPCRequest<
+    { transaction: string },
+    { transaction: string; signature: string }
+  >
 
   export type SignAndSendTransaction = RPCRequest<
     { transaction: string; options?: SendOptions },


### PR DESCRIPTION
# Description

- Adding `transaction` param over `solana_signTransaction` for `react-dapp-v2`;
- Add `signature` in `solana_signTransaction` response for `react-wallet-v2`;
- Add parsing for both base58 and base64 in `solana_signTransaction` request for `react-wallet-v2`