### PR TITLE
chore: better error handling

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/contexts/ClientContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/ClientContext.tsx
@@ -80,6 +80,7 @@ export function ClientContextProvider({
   const [isFetchingBalances, setIsFetchingBalances] = useState(false);
   const [isInitializing, setIsInitializing] = useState(false);
   const prevRelayerValue = useRef<string>("");
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const [balances, setBalances] = useState<AccountBalances>({});
   const [accounts, setAccounts] = useState<string[]>([]);
@@ -91,18 +92,32 @@ export function ClientContextProvider({
   );
   const [origin, setOrigin] = useState<string>(getAppMetadata().url);
   const reset = () => {
+    // Abort any in-flight balance fetches
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
     setSession(undefined);
     setBalances({});
     setAccounts([]);
     setChains([]);
     setRelayerRegion(DEFAULT_RELAY_URL!);
+    setIsFetchingBalances(false); // Clear loading state on reset
   };
 
   const getAccountBalances = async (_accounts: string[]) => {
+    if (!_accounts.length) return; // Early return if no accounts
+
+    // Create new abort controller for this fetch
+    abortControllerRef.current = new AbortController();
+    const { signal } = abortControllerRef.current;
+
     setIsFetchingBalances(true);
     try {
+      // Check if aborted before starting
+      if (signal.aborted) return;
+
       const arr = await Promise.all(
         _accounts.map(async (account) => {
+          if (signal.aborted) throw new Error("Aborted");
           const [namespace, reference, address] = account.split(":");
           const chainId = `${namespace}:${reference}`;
           const assets = await apiGetAccountBalance(address, chainId);
@@ -110,14 +125,21 @@ export function ClientContextProvider({
         })
       );
 
+      // Check again before updating state
+      if (signal.aborted) return;
+
       const balances: AccountBalances = {};
       arr.forEach(({ account, assets }) => {
         balances[account] = assets;
       });
       setBalances(balances);
     } catch (e) {
-      console.error(e);
+      if ((e as Error).message !== "Aborted") {
+        console.error(e);
+        toast.error("Failed to fetch balances", { position: "bottom-left" });
+      }
     } finally {
+      // Always clear loading state, even on abort
       setIsFetchingBalances(false);
     }
   };
@@ -212,19 +234,35 @@ export function ClientContextProvider({
 
   const disconnect = useCallback(async () => {
     if (typeof client === "undefined") {
-      throw new Error("WalletConnect is not initialized");
-    }
-    if (typeof session === "undefined") {
-      throw new Error("Session is not connected");
+      console.error("WalletConnect client not initialized");
+      toast.error("WalletConnect client not initialized", {
+        position: "bottom-left",
+      });
+      reset(); // Still reset local state if client never initialized
+      return;
     }
 
-    await client.disconnect({
-      topic: session.topic,
-      reason: getSdkError("USER_DISCONNECTED"),
-    });
+    // If no session, just reset and return
+    if (!session) {
+      reset();
+      return;
+    }
 
-    // Reset app state after disconnect.
-    reset();
+    try {
+      await client.disconnect({
+        topic: session.topic,
+        reason: getSdkError("USER_DISCONNECTED"),
+      });
+      // Only reset if disconnect succeeds
+      reset();
+    } catch (error) {
+      console.error("Disconnect error:", error);
+      toast.error(`Failed to disconnect: ${(error as Error).message}`, {
+        position: "bottom-left",
+      });
+      // Don't reset on error - session is still active, allow retry
+      throw error;
+    }
   }, [client, session]);
 
   const _subscribeToEvents = useCallback(

--- a/advanced/dapps/react-dapp-v2/src/modals/LoaderModal.tsx
+++ b/advanced/dapps/react-dapp-v2/src/modals/LoaderModal.tsx
@@ -8,18 +8,21 @@ import { SModalContainer, SModalParagraph, SModalTitle } from "./shared";
 interface LoaderModal {
   title: string;
   text?: string;
+  subtitle?: string;
+  isError?: boolean;
 }
 
 const LoaderModal = (props: LoaderModal) => {
-  const { title, text } = props;
+  const { title, text, subtitle, isError } = props;
   return (
     <>
       <SModalContainer>
         <SModalTitle>{title}</SModalTitle>
         <SContainer>
-          <Loader />
-          <br />
-          <SModalParagraph>{text}</SModalParagraph>
+          {!isError && <Loader />}
+          {!isError && <br />}
+          {text && <SModalParagraph>{text}</SModalParagraph>}
+          {subtitle && <SModalParagraph>{subtitle}</SModalParagraph>}
         </SContainer>
       </SModalContainer>
     </>


### PR DESCRIPTION
Handles errors around `Disconnect` in order to understand why Canary runs like https://reown-inc.slack.com/archives/C09FN4W5CHJ/p1760503860679929?thread_ts=1760475675.190519&cid=C09FN4W5CHJ are failing.

# Testing

Used the preview.