### PR TITLE
fix: use NEXT_PUBLIC_RELAY_URL env var for default relay endpoint

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/data/RelayerRegions.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/RelayerRegions.ts
@@ -12,7 +12,7 @@ type RelayerType = {
  */
 export const REGIONALIZED_RELAYER_ENDPOINTS: RelayerType[] = [
   {
-    value: 'wss://relay.walletconnect.com',
+    value: process.env.NEXT_PUBLIC_RELAY_URL || 'wss://relay.walletconnect.com',
     label: 'Default'
   },
 


### PR DESCRIPTION
  Replace hardcoded relay URL with environment variable to allow configuring different relay endpoints (e.g.,
  staging-relay.walletconnect.com) per deployment environment.

This hopefully fixes https://staging.react-wallet.walletconnect.com using `prod` Relay

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude <noreply@anthropic.com>