### PR TITLE
fix: missing accounts

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
@@ -84,6 +84,18 @@ export default function useInitialization() {
             }),
             createOrRestoreKadenaWallet().then(({ kadenaAddresses }) => {
               SettingsStore.setKadenaAddress(kadenaAddresses[0])
+            }),
+            createOrRestoreBip122Wallet().then(({ bip122Addresses }) => {
+              SettingsStore.setbip122Address(bip122Addresses[0])
+            }),
+            createOrRestoreSuiWallet().then(({ suiAddresses }) => {
+              SettingsStore.setSuiAddress(suiAddresses[0])
+            }),
+            createOrRestoreStacksWallet().then(({ stacksAddresses }) => {
+              SettingsStore.setStacksAddress('mainnet', stacksAddresses[0])
+            }),
+            createOrRestoreTonWallet().then(({ tonAddresses }) => {
+              SettingsStore.setTonAddress(tonAddresses[0])
             })
           ])
           console.log('All chain wallets initialized')


### PR DESCRIPTION
This PR fixes missing account initialization for several blockchain networks by adding wallet creation calls and address storage.

Key Changes:

- Added initialization for BIP122, Sui, Stacks, and TON wallets
- Configured SettingsStore to persist addresses for newly supported chains


caused by https://github.com/reown-com/web-examples/pull/934