### PR TITLE
fix: uses correct address in bip122 signmessage

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -1983,7 +1983,6 @@ export function JsonRpcContextProvider({
         console.log("testSignMessage", chainId, address);
         const method = DEFAULT_BIP122_METHODS.BIP122_SIGN_MESSAGE;
         const message = "This is a message to be signed for BIP122";
-        const shouldAddAddress = address !== getAddressFromAccount(accounts[0]);
         const result = await client!.request<{
           signature: string;
           address: string;
@@ -1994,8 +1993,8 @@ export function JsonRpcContextProvider({
             method,
             params: {
               message,
-              account: getAddressFromAccount(accounts[0]),
-              address: shouldAddAddress ? address : undefined,
+              account: address,
+              address: address,
             },
           },
         });


### PR DESCRIPTION
This PR fixes a bug in the BIP122 signMessage method where incorrect address references were being used. The fix ensures the method uses the correct address parameter passed to the function, aligning with the pattern used by other BIP122 methods.

Key changes:

- Removed broken logic that referenced an out-of-scope accounts[0] variable
- Changed the account parameter from using getAddressFromAccount(accounts[0]) to using the function's address parameter
- Simplified the address parameter to always use the function's address parameter instead of conditional logic