### PR TITLE
feat: add tron_sendTransaction method and fix TRX balance display

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/chains/tron.ts
+++ b/advanced/dapps/react-dapp-v2/src/chains/tron.ts
@@ -10,7 +10,7 @@ export const TronChainData: ChainsMap = {
   },
   "0xcd8690dc": {
     id: "tron:0xcd8690dc",
-    name: "Tron Testnet",
+    name: "Tron Testnet (Nile)",
     rpc: [],
     slip44: 195,
     testnet: true,
@@ -23,7 +23,7 @@ export const TronMetadata: NamespaceMetadata = {
     logo: "/assets/tron.png",
     rgb: "183, 62, 49",
   },
-  // Tron TestNet
+  // Tron Testnet (Nile)
   "0xcd8690dc": {
     logo: "assets/tron.png",
     rgb: "183, 62, 49",

--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -251,6 +251,7 @@ export enum DEFAULT_MULTIVERSX_EVENTS {}
 export enum DEFAULT_TRON_METHODS {
   TRON_SIGN_TRANSACTION = "tron_signTransaction",
   TRON_SIGN_MESSAGE = "tron_signMessage",
+  TRON_SEND_TRANSACTION = "tron_sendTransaction",
 }
 
 export enum DEFAULT_TRON_EVENTS {}

--- a/advanced/dapps/react-dapp-v2/src/helpers/api.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/api.ts
@@ -231,13 +231,15 @@ export const apiGetTronAccountBalance = async (
       balance: balanceInTrx.toString(),
       symbol: "TRX",
       name: "TRX",
+      decimals: 0,
     };
   } catch (error) {
     console.error("Failed to fetch TRON balance:", error);
     return {
       balance: "0",
       symbol: "TRX",
-      name: "TRON",
+      name: "TRX",
+      decimals: 0,
     };
   }
 };

--- a/advanced/dapps/react-dapp-v2/src/pages/index.tsx
+++ b/advanced/dapps/react-dapp-v2/src/pages/index.tsx
@@ -466,6 +466,10 @@ const Home: NextPage = () => {
       openRequestModal();
       await tronRpc.testSignMessage(chainId, address);
     };
+    const onSendTransaction = async (chainId: string, address: string) => {
+      openRequestModal();
+      await tronRpc.testSendTransaction(chainId, address);
+    };
     return [
       {
         method: DEFAULT_TRON_METHODS.TRON_SIGN_TRANSACTION,
@@ -474,6 +478,10 @@ const Home: NextPage = () => {
       {
         method: DEFAULT_TRON_METHODS.TRON_SIGN_MESSAGE,
         callback: onSignMessage,
+      },
+      {
+        method: DEFAULT_TRON_METHODS.TRON_SEND_TRANSACTION,
+        callback: onSendTransaction,
       },
     ];
   };

--- a/advanced/wallets/react-wallet-v2/src/data/TronData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/TronData.ts
@@ -48,5 +48,6 @@ export const TRON_CHAINS = { ...TRON_MAINNET_CHAINS, ...TRON_TEST_CHAINS }
  */
 export const TRON_SIGNING_METHODS = {
   TRON_SIGN_TRANSACTION: 'tron_signTransaction',
-  TRON_SIGN_MESSAGE: 'tron_signMessage'
+  TRON_SIGN_MESSAGE: 'tron_signMessage',
+  TRON_SEND_TRANSACTION: 'tron_sendTransaction'
 }

--- a/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts
@@ -158,6 +158,7 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
 
         case TRON_SIGNING_METHODS.TRON_SIGN_MESSAGE:
         case TRON_SIGNING_METHODS.TRON_SIGN_TRANSACTION:
+        case TRON_SIGNING_METHODS.TRON_SEND_TRANSACTION:
           return ModalStore.open('SessionSignTronModal', { requestEvent, requestSession })
         case TEZOS_SIGNING_METHODS.TEZOS_GET_ACCOUNTS:
         case TEZOS_SIGNING_METHODS.TEZOS_SEND:

--- a/advanced/wallets/react-wallet-v2/src/lib/TronLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TronLib.ts
@@ -50,8 +50,15 @@ export default class TronLib {
   }
 
   public async signTransaction(transaction: any) {
-    // The transaction parameter is expected to be unwrapped already.
     const signedtxn = await this.tronWeb.trx.sign(transaction)
     return signedtxn
+  }
+
+  public async sendTransaction(signedTransaction: any) {
+    const result = await this.tronWeb.trx.sendRawTransaction(signedTransaction)
+    return {
+      result: result.result ?? false,
+      txid: result.txid ?? signedTransaction.txID
+    }
   }
 }

--- a/advanced/wallets/react-wallet-v2/src/utils/TronRequestHandlerUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/TronRequestHandlerUtil.ts
@@ -38,6 +38,13 @@ export async function approveTronRequest(
 
       return formatJsonRpcResult(id, signedTransaction)
 
+    case TRON_SIGNING_METHODS.TRON_SEND_TRANSACTION:
+      // Accept unsigned transaction, sign it, and broadcast
+      const txToSend = request.params.transaction?.transaction || request.params.transaction
+      const signedTxToSend = await wallet.signTransaction(txToSend)
+      const sendResult = await wallet.sendTransaction(signedTxToSend)
+      return formatJsonRpcResult(id, sendResult)
+
     default:
       throw new Error(getSdkError('INVALID_METHOD').message)
   }


### PR DESCRIPTION
## Summary

- Add `tron_sendTransaction` RPC method to both wallet and dapp per [WalletConnect Tron spec](https://docs.walletconnect.network/wallet-sdk/chain-support/tron#tron_sendtransaction)
- Wallet signs and broadcasts transaction in a single approval flow (similar to `eth_sendTransaction`)
- Fix TRX balance display that was incorrectly dividing by 10^18
- Rename "Tron Testnet" to "Tron Testnet (Nile)" for clarity

## Changes

### Wallet (react-wallet-v2)
- Added `TRON_SEND_TRANSACTION` method constant
- Added `sendTransaction()` to TronLib that broadcasts via `tronWeb.trx.sendRawTransaction()`
- Added request handler that signs and broadcasts in one step
- Added event manager case for the new method

### Dapp (react-dapp-v2)
- Added `TRON_SEND_TRANSACTION` to constants
- Added `testSendTransaction` RPC method that sends unsigned transaction
- Added action button for send transaction
- Fixed TRX balance display by setting `decimals: 0` (balance already converted from SUN)

## Test plan

- [ ] Connect wallet to dapp on Tron Testnet (Nile)
- [ ] Verify TRX balance displays correctly (e.g., 2000 TRX not 0.000000000000002)
- [ ] Test `tron_signTransaction` - should sign and return signed tx
- [ ] Test `tron_signMessage` - should sign message and verify
- [ ] Test `tron_sendTransaction` - should show single approval, sign, broadcast, and return txid
- [ ] Verify transaction on https://nile.tronscan.org