### PR TITLE
fix(wallet): normalize valid_until timestamp in TON sendMessage

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
@@ -121,13 +121,9 @@ export default class TonLib {
         throw new TonValidationError('Valid until must be a number.')
       }
 
-      // Normalize to seconds if milliseconds were provided
-      const validUntilSeconds =
-        params.valid_until > 10_000_000_000
-          ? Math.floor(params.valid_until / 1000)
-          : params.valid_until
+      const validUntilSeconds = this.normalizeValidUntil(params.valid_until)
 
-      if (validUntilSeconds < Date.now() / 1000) {
+      if (validUntilSeconds! < Math.floor(Date.now() / 1000)) {
         throw new TonValidationError('Message is expired.')
       }
     }


### PR DESCRIPTION
## Summary
- Fix "bitLength is too small" error when dApps send `valid_until` in milliseconds
- Add `normalizeValidUntil()` helper to convert milliseconds to seconds when needed
- Update validation to normalize timestamp before checking expiration

## Problem
The `valid_until` parameter in `ton_sendMessage` requests may be sent in milliseconds by some dApps, but TON uses 32-bit timestamps (seconds). Values over ~4.3 billion overflow, causing "bitLength is too small" errors.

## Solution
Detect millisecond timestamps by checking if the value exceeds 10 billion (year 2286 in seconds), and convert to seconds when needed. This normalization is applied both in validation and when passing to `createTransfer`.

## Test plan
- [ ] Build the project to ensure no TypeScript errors
- [ ] Test sending a TON message with a millisecond timestamp (e.g., `Date.now()`) - should work without overflow error
- [ ] Test sending a TON message with a second timestamp - should still work correctly
- [ ] Test that expired messages are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)