### PR TITLE
feat(react-wallet): derive Solana E2E accounts from mnemonic

### DIFF
--- a/advanced/wallets/react-wallet-v2/package.json
+++ b/advanced/wallets/react-wallet-v2/package.json
@@ -7,7 +7,8 @@
     "start": "next start -p 3001",
     "lint": "next lint",
     "prettier": "prettier --check '**/*.{js,ts,jsx,tsx}'",
-    "prettier:write": "prettier --write '**/*.{js,ts,jsx,tsx}'"
+    "prettier:write": "prettier --write '**/*.{js,ts,jsx,tsx}'",
+    "test:e2e-derivation": "node scripts/test-solana-e2e-derivation.js"
   },
   "dependencies": {
     "@cosmjs/amino": "0.32.4",

--- a/advanced/wallets/react-wallet-v2/scripts/test-solana-e2e-derivation.js
+++ b/advanced/wallets/react-wallet-v2/scripts/test-solana-e2e-derivation.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict')
+
+const { Keypair } = require('@solana/web3.js')
+const { mnemonicToSeedSync } = require('bip39')
+const { derivePath } = require('ed25519-hd-key')
+
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const CASES = [
+  {
+    path: "m/44'/501'/0'/0'",
+    address: 'HAgk14JpMQLgt6rVgv7cBQFJWFto5Dqxi472uT3DKpqk'
+  },
+  {
+    path: "m/44'/501'/1'/0'",
+    address: 'Hh8QwFUA6MtVu1qAoq12ucvFHNwCcVTV7hpWjeY1Hztb'
+  }
+]
+
+function deriveAddress(path) {
+  const seed = mnemonicToSeedSync(MNEMONIC)
+  const { key } = derivePath(path, seed.toString('hex'))
+
+  return Keypair.fromSeed(key).publicKey.toBase58()
+}
+
+const addresses = CASES.map(({ path, address }) => {
+  const first = deriveAddress(path)
+  const second = deriveAddress(path)
+
+  assert.equal(first, second, `${path} should be deterministic`)
+  assert.equal(first, address, `${path} should match its fixture address`)
+
+  return first
+})
+
+assert.notEqual(addresses[0], addresses[1], 'account indexes should derive distinct addresses')

--- a/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
@@ -44,7 +44,9 @@ export default function useInitialization() {
       const e2eMnemonic = await fetchE2ECredentials()
 
       // Initialize EIP155 wallet first (required)
-      const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
+      const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet({
+        mnemonic: e2eMnemonic
+      })
       if (!eip155Addresses || !eip155Addresses[0]) {
         throw new Error('Failed to create EIP155 wallet')
       }

--- a/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
+++ b/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts
@@ -41,7 +41,7 @@ export default function useInitialization() {
       console.log('Starting wallet initialization...')
 
       // Check for E2E credentials (decrypt via server if provided in URL)
-      await fetchE2ECredentials()
+      const e2eMnemonic = await fetchE2ECredentials()
 
       // Initialize EIP155 wallet first (required)
       const { eip155Addresses, eip155Wallets } = createOrRestoreEIP155Wallet()
@@ -68,7 +68,7 @@ export default function useInitialization() {
             createOrRestoreCosmosWallet().then(({ cosmosAddresses }) => {
               SettingsStore.setCosmosAddress(cosmosAddresses[0])
             }),
-            createOrRestoreSolanaWallet().then(({ solanaAddresses }) => {
+            createOrRestoreSolanaWallet({ mnemonic: e2eMnemonic }).then(({ solanaAddresses }) => {
               SettingsStore.setSolanaAddress(solanaAddresses[0])
             }),
             createOrRestorePolkadotWallet().then(({ polkadotAddresses }) => {

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
@@ -17,9 +17,8 @@ let address2: string
  * 1. Pre-encrypt mnemonic with scripts/encrypt-mnemonic.js
  * 2. Store encrypted value in E2E_ENCRYPTED_MNEMONIC secret
  * 3. Navigate to wallet with ?e2e_encrypted=<encrypted_value>
- * 4. This function decrypts via /api/e2e/decrypt, stores the mnemonic for EVM
- *    initialization, and returns it for the other namespace initializers
- * 5. createOrRestoreEIP155Wallet() reads its copy from localStorage
+ * 4. This function decrypts via /api/e2e/decrypt and returns the mnemonic
+ *    directly to the namespace initializers without persisting it
  */
 export async function fetchE2ECredentials(): Promise<string | undefined> {
   if (typeof window === 'undefined') {
@@ -48,8 +47,7 @@ export async function fetchE2ECredentials(): Promise<string | undefined> {
 
     const data = await response.json()
 
-    if (data.mnemonic) {
-      localStorage.setItem('E2E_MNEMONIC', data.mnemonic)
+    if (typeof data.mnemonic === 'string') {
       return data.mnemonic
     }
 
@@ -62,20 +60,14 @@ export async function fetchE2ECredentials(): Promise<string | undefined> {
 /**
  * Utilities
  */
-export function createOrRestoreEIP155Wallet() {
-  // Check for E2E mnemonic (set by fetchE2ECredentials)
-  const e2eMnemonic = localStorage.getItem('E2E_MNEMONIC')
-
-  if (e2eMnemonic) {
-    // E2E mode: Use provided mnemonic for deterministic wallet
+export function createOrRestoreEIP155Wallet({ mnemonic }: { mnemonic?: string } = {}) {
+  if (mnemonic) {
+    // Remove credentials persisted by the legacy E2E handoff.
     localStorage.removeItem('E2E_MNEMONIC')
-
-    // Persist as regular mnemonic so it survives page navigation
-    localStorage.setItem('EIP155_MNEMONIC_1', e2eMnemonic)
-
-    wallet1 = EIP155Lib.init({ mnemonic: e2eMnemonic })
+    localStorage.removeItem('EIP155_MNEMONIC_1')
+    localStorage.removeItem('EIP155_MNEMONIC_2')
+    wallet1 = EIP155Lib.init({ mnemonic })
     wallet2 = EIP155Lib.init({})
-    localStorage.setItem('EIP155_MNEMONIC_2', wallet2.getMnemonic())
   } else {
     // Normal mode: Restore from localStorage or create new
     const mnemonic1 = localStorage.getItem('EIP155_MNEMONIC_1')

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
@@ -17,12 +17,13 @@ let address2: string
  * 1. Pre-encrypt mnemonic with scripts/encrypt-mnemonic.js
  * 2. Store encrypted value in E2E_ENCRYPTED_MNEMONIC secret
  * 3. Navigate to wallet with ?e2e_encrypted=<encrypted_value>
- * 4. This function decrypts via /api/e2e/decrypt and stores in localStorage
- * 5. createOrRestoreEIP155Wallet() reads from localStorage
+ * 4. This function decrypts via /api/e2e/decrypt, stores the mnemonic for EVM
+ *    initialization, and returns it for the other namespace initializers
+ * 5. createOrRestoreEIP155Wallet() reads its copy from localStorage
  */
-export async function fetchE2ECredentials(): Promise<boolean> {
+export async function fetchE2ECredentials(): Promise<string | undefined> {
   if (typeof window === 'undefined') {
-    return false
+    return undefined
   }
 
   const urlParams = new URLSearchParams(window.location.search)
@@ -34,7 +35,7 @@ export async function fetchE2ECredentials(): Promise<boolean> {
   }
 
   if (!encrypted) {
-    return false
+    return undefined
   }
 
   try {
@@ -42,19 +43,19 @@ export async function fetchE2ECredentials(): Promise<boolean> {
     const response = await fetch(url)
 
     if (!response.ok) {
-      return false
+      return undefined
     }
 
     const data = await response.json()
 
     if (data.mnemonic) {
       localStorage.setItem('E2E_MNEMONIC', data.mnemonic)
-      return true
+      return data.mnemonic
     }
 
-    return false
+    return undefined
   } catch (error) {
-    return false
+    return undefined
   }
 }
 

--- a/advanced/wallets/react-wallet-v2/src/utils/SolanaWalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SolanaWalletUtil.ts
@@ -24,55 +24,7 @@ export function deriveSolanaKeypair(mnemonic: string, path: string): Keypair {
   return Keypair.fromSeed(key)
 }
 
-function persistWallets() {
-  localStorage.setItem('SOLANA_SECRET_KEY_1', JSON.stringify(Array.from(wallet1.keypair.secretKey)))
-  localStorage.setItem('SOLANA_SECRET_KEY_2', JSON.stringify(Array.from(wallet2.keypair.secretKey)))
-}
-
-export async function createOrRestoreSolanaWallet({ mnemonic }: { mnemonic?: string } = {}) {
-  if (mnemonic) {
-    const [path1, path2] = SOLANA_E2E_DERIVATION_PATHS
-    wallet1 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path1).secretKey })
-    wallet2 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path2).secretKey })
-    persistWallets()
-  } else {
-    const secretKey1 = localStorage.getItem('SOLANA_SECRET_KEY_1')
-    const secretKey2 = localStorage.getItem('SOLANA_SECRET_KEY_2')
-
-    if (secretKey1 && secretKey2) {
-      try {
-        const secretArray1: number[] = Object.values(JSON.parse(secretKey1))
-        wallet1 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray1) })
-      } catch (error) {
-        console.error('Failed to init Solana wallet1, creating new one:', error)
-        localStorage.removeItem('SOLANA_SECRET_KEY_1')
-        wallet1 = SolanaLib.init({})
-        localStorage.setItem(
-          'SOLANA_SECRET_KEY_1',
-          JSON.stringify(Array.from(wallet1.keypair.secretKey))
-        )
-      }
-      try {
-        const secretArray2: number[] = Object.values(JSON.parse(secretKey2))
-        wallet2 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray2) })
-      } catch (error) {
-        console.error('Failed to init Solana wallet2, creating new one:', error)
-        localStorage.removeItem('SOLANA_SECRET_KEY_2')
-        wallet2 = SolanaLib.init({})
-        localStorage.setItem(
-          'SOLANA_SECRET_KEY_2',
-          JSON.stringify(Array.from(wallet2.keypair.secretKey))
-        )
-      }
-    } else {
-      wallet1 = SolanaLib.init({})
-      wallet2 = SolanaLib.init({})
-
-      // Don't store secretKey in local storage in a production project!
-      persistWallets()
-    }
-  }
-
+async function registerSolanaWallets() {
   address1 = await wallet1.getAddress()
   address2 = await wallet2.getAddress()
 
@@ -86,4 +38,62 @@ export async function createOrRestoreSolanaWallet({ mnemonic }: { mnemonic?: str
     solanaWallets,
     solanaAddresses
   }
+}
+
+export async function createOrRestoreSolanaWallet({ mnemonic }: { mnemonic?: string } = {}) {
+  if (mnemonic) {
+    const [path1, path2] = SOLANA_E2E_DERIVATION_PATHS
+    // E2E credentials are derived in memory on every load and are never persisted.
+    localStorage.removeItem('SOLANA_SECRET_KEY_1')
+    localStorage.removeItem('SOLANA_SECRET_KEY_2')
+    wallet1 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path1).secretKey })
+    wallet2 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path2).secretKey })
+
+    return registerSolanaWallets()
+  }
+
+  const secretKey1 = localStorage.getItem('SOLANA_SECRET_KEY_1')
+  const secretKey2 = localStorage.getItem('SOLANA_SECRET_KEY_2')
+
+  if (secretKey1 && secretKey2) {
+    try {
+      const secretArray1: number[] = Object.values(JSON.parse(secretKey1))
+      wallet1 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray1) })
+    } catch (error) {
+      console.error('Failed to init Solana wallet1, creating new one:', error)
+      localStorage.removeItem('SOLANA_SECRET_KEY_1')
+      wallet1 = SolanaLib.init({})
+      localStorage.setItem(
+        'SOLANA_SECRET_KEY_1',
+        JSON.stringify(Array.from(wallet1.keypair.secretKey))
+      )
+    }
+    try {
+      const secretArray2: number[] = Object.values(JSON.parse(secretKey2))
+      wallet2 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray2) })
+    } catch (error) {
+      console.error('Failed to init Solana wallet2, creating new one:', error)
+      localStorage.removeItem('SOLANA_SECRET_KEY_2')
+      wallet2 = SolanaLib.init({})
+      localStorage.setItem(
+        'SOLANA_SECRET_KEY_2',
+        JSON.stringify(Array.from(wallet2.keypair.secretKey))
+      )
+    }
+  } else {
+    wallet1 = SolanaLib.init({})
+    wallet2 = SolanaLib.init({})
+
+    // Don't store secretKey in local storage in a production project!
+    localStorage.setItem(
+      'SOLANA_SECRET_KEY_1',
+      JSON.stringify(Array.from(wallet1.keypair.secretKey))
+    )
+    localStorage.setItem(
+      'SOLANA_SECRET_KEY_2',
+      JSON.stringify(Array.from(wallet2.keypair.secretKey))
+    )
+  }
+
+  return registerSolanaWallets()
 }

--- a/advanced/wallets/react-wallet-v2/src/utils/SolanaWalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/SolanaWalletUtil.ts
@@ -1,4 +1,10 @@
+import { Keypair } from '@solana/web3.js'
+import { mnemonicToSeedSync } from 'bip39'
+import { derivePath } from 'ed25519-hd-key'
+
 import SolanaLib from '@/lib/SolanaLib'
+
+export const SOLANA_E2E_DERIVATION_PATHS = ["m/44'/501'/0'/0'", "m/44'/501'/1'/0'"] as const
 
 export let wallet1: SolanaLib
 export let wallet2: SolanaLib
@@ -11,48 +17,60 @@ let address2: string
 /**
  * Utilities
  */
-export async function createOrRestoreSolanaWallet() {
-  const secretKey1 = localStorage.getItem('SOLANA_SECRET_KEY_1')
-  const secretKey2 = localStorage.getItem('SOLANA_SECRET_KEY_2')
+export function deriveSolanaKeypair(mnemonic: string, path: string): Keypair {
+  const seed = mnemonicToSeedSync(mnemonic)
+  const { key } = derivePath(path, seed.toString('hex'))
 
-  if (secretKey1 && secretKey2) {
-    try {
-      const secretArray1: number[] = Object.values(JSON.parse(secretKey1))
-      wallet1 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray1) })
-    } catch (error) {
-      console.error('Failed to init Solana wallet1, creating new one:', error)
-      localStorage.removeItem('SOLANA_SECRET_KEY_1')
-      wallet1 = SolanaLib.init({})
-      localStorage.setItem(
-        'SOLANA_SECRET_KEY_1',
-        JSON.stringify(Array.from(wallet1.keypair.secretKey))
-      )
-    }
-    try {
-      const secretArray2: number[] = Object.values(JSON.parse(secretKey2))
-      wallet2 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray2) })
-    } catch (error) {
-      console.error('Failed to init Solana wallet2, creating new one:', error)
-      localStorage.removeItem('SOLANA_SECRET_KEY_2')
-      wallet2 = SolanaLib.init({})
-      localStorage.setItem(
-        'SOLANA_SECRET_KEY_2',
-        JSON.stringify(Array.from(wallet2.keypair.secretKey))
-      )
-    }
+  return Keypair.fromSeed(key)
+}
+
+function persistWallets() {
+  localStorage.setItem('SOLANA_SECRET_KEY_1', JSON.stringify(Array.from(wallet1.keypair.secretKey)))
+  localStorage.setItem('SOLANA_SECRET_KEY_2', JSON.stringify(Array.from(wallet2.keypair.secretKey)))
+}
+
+export async function createOrRestoreSolanaWallet({ mnemonic }: { mnemonic?: string } = {}) {
+  if (mnemonic) {
+    const [path1, path2] = SOLANA_E2E_DERIVATION_PATHS
+    wallet1 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path1).secretKey })
+    wallet2 = SolanaLib.init({ secretKey: deriveSolanaKeypair(mnemonic, path2).secretKey })
+    persistWallets()
   } else {
-    wallet1 = SolanaLib.init({})
-    wallet2 = SolanaLib.init({})
+    const secretKey1 = localStorage.getItem('SOLANA_SECRET_KEY_1')
+    const secretKey2 = localStorage.getItem('SOLANA_SECRET_KEY_2')
 
-    // Don't store secretKey in local storage in a production project!
-    localStorage.setItem(
-      'SOLANA_SECRET_KEY_1',
-      JSON.stringify(Array.from(wallet1.keypair.secretKey))
-    )
-    localStorage.setItem(
-      'SOLANA_SECRET_KEY_2',
-      JSON.stringify(Array.from(wallet2.keypair.secretKey))
-    )
+    if (secretKey1 && secretKey2) {
+      try {
+        const secretArray1: number[] = Object.values(JSON.parse(secretKey1))
+        wallet1 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray1) })
+      } catch (error) {
+        console.error('Failed to init Solana wallet1, creating new one:', error)
+        localStorage.removeItem('SOLANA_SECRET_KEY_1')
+        wallet1 = SolanaLib.init({})
+        localStorage.setItem(
+          'SOLANA_SECRET_KEY_1',
+          JSON.stringify(Array.from(wallet1.keypair.secretKey))
+        )
+      }
+      try {
+        const secretArray2: number[] = Object.values(JSON.parse(secretKey2))
+        wallet2 = SolanaLib.init({ secretKey: Uint8Array.from(secretArray2) })
+      } catch (error) {
+        console.error('Failed to init Solana wallet2, creating new one:', error)
+        localStorage.removeItem('SOLANA_SECRET_KEY_2')
+        wallet2 = SolanaLib.init({})
+        localStorage.setItem(
+          'SOLANA_SECRET_KEY_2',
+          JSON.stringify(Array.from(wallet2.keypair.secretKey))
+        )
+      }
+    } else {
+      wallet1 = SolanaLib.init({})
+      wallet2 = SolanaLib.init({})
+
+      // Don't store secretKey in local storage in a production project!
+      persistWallets()
+    }
   }
 
   address1 = await wallet1.getAddress()


### PR DESCRIPTION
## Summary

- return the decrypted E2E mnemonic directly to wallet initialization without storing it
- derive React Wallet EVM and Solana E2E accounts in memory from the existing mnemonic
- remove legacy E2E credential caches when E2E mode starts
- preserve the normal random/create-or-restore flow outside E2E mode
- add deterministic fixtures for both Solana account indexes

## Security

The decrypted mnemonic and derived E2E private keys are never written to local storage, logs, or the repository. Only public fixture addresses are exposed outside wallet memory. The existing non-E2E sample-wallet persistence behavior is unchanged.

## Testing

- `pnpm test:e2e-derivation`
- `pnpm exec tsc --noEmit --incremental false`
- changed-file Prettier checks

## Existing repository issues

- `pnpm lint` invokes the removed `next lint` command with the installed Next version
- `pnpm build` compiles and typechecks, then fails while collecting `/account` because server-side `localStorage.getItem` is not a function