### PR TITLE
fix(sui): migrate examples from deprecated JSON-RPC to GraphQL RPC

### DIFF
--- a/advanced/dapps/react-dapp-v2/package.json
+++ b/advanced/dapps/react-dapp-v2/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ethereumjs/tx": "10.1.1",
     "@multiversx/sdk-core": "15.3.2",
-    "@mysten/sui": "2.3.1",
+    "@mysten/sui": "2.23.2",
     "@noble/curves": "2.0.1",
     "@noble/hashes": "2.0.1",
     "@polkadot/util-crypto": "14.0.1",

--- a/advanced/dapps/react-dapp-v2/pnpm-lock.yaml
+++ b/advanced/dapps/react-dapp-v2/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 15.3.2
         version: 15.3.2(bignumber.js@9.1.2)(protobufjs@7.4.0)
       '@mysten/sui':
-        specifier: 2.3.1
-        version: 2.3.1(typescript@5.8.3)
+        specifier: 2.23.2
+        version: 2.23.2(typescript@5.8.3)
       '@noble/curves':
         specifier: 2.0.1
         version: 2.0.1
@@ -176,19 +176,19 @@ importers:
 
 packages:
 
-  '@0no-co/graphql.web@1.1.2':
-    resolution: {integrity: sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==}
+  '@0no-co/graphql.web@1.3.3':
+    resolution: {integrity: sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     peerDependenciesMeta:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.12.16':
-    resolution: {integrity: sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==}
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
@@ -371,25 +371,25 @@ packages:
     resolution: {integrity: sha512-r2EhaeEmLZXVs1dT2HJFQysAkr63ZWATu/9tgYSp1IlvjvwyC++DLg5kCDwMM49HBq3sOAhrPnXkoqf9DV2gbw==}
     engines: {node: '>=20'}
 
-  '@gql.tada/cli-utils@1.7.2':
-    resolution: {integrity: sha512-Qbc7hbLvCz6IliIJpJuKJa9p05b2Jona7ov7+qofCsMRxHRZE1kpAmZMvL8JCI4c0IagpIlWNaMizXEQUe8XjQ==}
+  '@gql.tada/cli-utils@1.9.3':
+    resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
     peerDependencies:
-      '@0no-co/graphqlsp': ^1.12.13
-      '@gql.tada/svelte-support': 1.0.1
-      '@gql.tada/vue-support': 1.0.1
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@gql.tada/svelte-support':
         optional: true
       '@gql.tada/vue-support':
         optional: true
 
-  '@gql.tada/internal@1.0.8':
-    resolution: {integrity: sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==}
+  '@gql.tada/internal@1.2.2':
+    resolution: {integrity: sha512-4lZcElPP6MC8Ct8KN70LR2WQsHjbAsyAmTGG09VsOPhx738UFIYaL0S1XiI2pqq2tj/sDs/y3b9jvKoWGL7iuQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -452,89 +452,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -608,15 +624,15 @@ packages:
   '@multiversx/sdk-transaction-decoder@1.0.2':
     resolution: {integrity: sha512-j43QsKquu8N51WLmVlJ7dV2P3A1448R7/ktvl8r3i6wRMpfdtzDPNofTdHmMRT7DdQdvs4+RNgz8hVKL11Etsw==}
 
-  '@mysten/bcs@2.0.1':
-    resolution: {integrity: sha512-/q1uC5Vw/RjXzR4fE9QiIwmTvRx9BstduxkR1j1Z5EbE7ZJynLkFKcJJlXRcnnEytIPcsyiR+TkQixzSbz3msQ==}
+  '@mysten/bcs@2.1.0':
+    resolution: {integrity: sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==}
 
-  '@mysten/sui@2.3.1':
-    resolution: {integrity: sha512-EEDK/tvdhBn88ss7beqYtDPaWmE5wgvzcMAsKIPxCMjMpWgjJEUqd6mCAA5qz6WEAEtferSYYhQ2IybF3doskA==}
+  '@mysten/sui@2.23.2':
+    resolution: {integrity: sha512-cUnE4v/0NSKsdihU09qmSS82pqlRPb6XjPO+iU5KAqSn5rRsEcbJZ/lTsW1INfnmWeHs6/Xobv+vEedDlQ1CZw==}
     engines: {node: '>=22'}
 
-  '@mysten/utils@0.3.0':
-    resolution: {integrity: sha512-paVyFTP+1yHXDO8uorU6YuT1EAIh/GMKXeHbxtGFPJbLzwc5jk1qfUMrks/S7MAwJHMOHcSOx+e2Mwx8ejaIew==}
+  '@mysten/utils@0.4.0':
+    resolution: {integrity: sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==}
 
   '@napi-rs/wasm-runtime@0.2.7':
     resolution: {integrity: sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==}
@@ -644,24 +660,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -701,6 +721,14 @@ packages:
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.3.0':
+    resolution: {integrity: sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/ed25519@1.7.3':
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
@@ -728,6 +756,14 @@ packages:
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/secp256k1@1.7.1':
@@ -905,14 +941,17 @@ packages:
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
-  '@scure/bip32@2.0.1':
-    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
@@ -920,8 +959,8 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@scure/bip39@2.0.1':
-    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@scure/sr25519@0.2.0':
     resolution: {integrity: sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==}
@@ -1150,21 +1189,25 @@ packages:
     resolution: {integrity: sha512-fp4Azi8kHz6TX8SFmKfyScZrMLfp++uRm2srpqRjsRZIIBzH74NtSkdEUHImR4G7f7XJ+sVZjCc6KDDK04YEpQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-arm64-musl@1.2.2':
     resolution: {integrity: sha512-gMiG3DCFioJxdGBzhlL86KcFgt9HGz0iDhw0YVYPsShItpN5pqIkNrI+L/Q/0gfDiGrfcE0X3VANSYIPmqEAlQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-linux-x64-gnu@1.2.2':
     resolution: {integrity: sha512-n/4n2CxaUF9tcaJxEaZm+lqvaw2gflfWQ1R9I7WQgYkKEKbRKbpG/R3hopYdUmLSRI4xaW1Cy0Bz40eS2Yi4Sw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-musl@1.2.2':
     resolution: {integrity: sha512-cHyhAr6rlYYbon1L2Ag449YCj3p6XMfcYTP0AQX+KkQo025d1y/VFtPWvjMhuEsE2lLvtHm7GdJozj6BOMtzVg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-wasm32-wasi@1.2.2':
     resolution: {integrity: sha512-eogDKuICghDLGc32FtP+WniG38IB1RcGOGz0G3z8406dUdjJvxfHGuGs/dSlM9YEp/v0lEqhJ4mBu6X2nL9pog==}
@@ -2271,14 +2314,14 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  gql.tada@1.9.0:
-    resolution: {integrity: sha512-1LMiA46dRs5oF7Qev6vMU32gmiNvM3+3nHoQZA9K9j2xQzH8xOAWnnJrLSbZOFHTSdFxqn86TL6beo1/7ja/aA==}
+  gql.tada@1.11.3:
+    resolution: {integrity: sha512-5JCI4j2f0nug8ILaCQys/yjOP78QqqjVUf47OQsME63rZfemsHT3e5vcfbHsnZiG6vxyqpKUJArtXEVwSefUhw==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  graphql@16.12.0:
-    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   h3@1.15.5:
@@ -3704,6 +3747,14 @@ packages:
       typescript:
         optional: true
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3867,14 +3918,14 @@ packages:
 
 snapshots:
 
-  '@0no-co/graphql.web@1.1.2(graphql@16.12.0)':
+  '@0no-co/graphql.web@1.3.3(graphql@16.14.2)':
     optionalDependencies:
-      graphql: 16.12.0
+      graphql: 16.14.2
 
-  '@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.8.3)':
+  '@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.8.3)':
     dependencies:
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.8.3)
-      graphql: 16.12.0
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.8.3)
+      graphql: 16.14.2
       typescript: 5.8.3
 
   '@adraffy/ens-normalize@1.10.1': {}
@@ -4124,22 +4175,22 @@ snapshots:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
 
-  '@gql.tada/cli-utils@1.7.2(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.8.3))(graphql@16.12.0)(typescript@5.8.3)':
+  '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.8.3))(graphql@16.14.2)(typescript@5.8.3)':
     dependencies:
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.12.0)(typescript@5.8.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.8.3)
-      graphql: 16.12.0
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.8.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.8.3)
+      graphql: 16.14.2
       typescript: 5.8.3
 
-  '@gql.tada/internal@1.0.8(graphql@16.12.0)(typescript@5.8.3)':
+  '@gql.tada/internal@1.2.2(graphql@16.14.2)(typescript@5.8.3)':
     dependencies:
-      '@0no-co/graphql.web': 1.1.2(graphql@16.12.0)
-      graphql: 16.12.0
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      graphql: 16.14.2
       typescript: 5.8.3
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
     dependencies:
-      graphql: 16.12.0
+      graphql: 16.14.2
 
   '@hono/node-server@1.19.9(hono@4.11.9)':
     dependencies:
@@ -4335,36 +4386,36 @@ snapshots:
     dependencies:
       bech32: 2.0.0
 
-  '@mysten/bcs@2.0.1':
+  '@mysten/bcs@2.1.0':
     dependencies:
-      '@mysten/utils': 0.3.0
-      '@scure/base': 2.0.0
+      '@mysten/utils': 0.4.0
+      '@scure/base': 2.2.0
 
-  '@mysten/sui@2.3.1(typescript@5.8.3)':
+  '@mysten/sui@2.23.2(typescript@5.8.3)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
-      '@mysten/bcs': 2.0.1
-      '@mysten/utils': 0.3.0
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@mysten/bcs': 2.1.0
+      '@mysten/utils': 0.4.0
+      '@noble/curves': 2.3.0
+      '@noble/hashes': 2.3.0
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
-      '@scure/base': 2.0.0
-      '@scure/bip32': 2.0.1
-      '@scure/bip39': 2.0.1
-      gql.tada: 1.9.0(graphql@16.12.0)(typescript@5.8.3)
-      graphql: 16.12.0
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.11.3(graphql@16.14.2)(typescript@5.8.3)
+      graphql: 16.14.2
       poseidon-lite: 0.2.1
-      valibot: 1.2.0(typescript@5.8.3)
+      valibot: 1.4.2(typescript@5.8.3)
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - typescript
 
-  '@mysten/utils@0.3.0':
+  '@mysten/utils@0.4.0':
     dependencies:
-      '@scure/base': 2.0.0
+      '@scure/base': 2.2.0
 
   '@napi-rs/wasm-runtime@0.2.7':
     dependencies:
@@ -4429,6 +4480,14 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
 
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/curves@2.3.0':
+    dependencies:
+      '@noble/hashes': 2.3.0
+
   '@noble/ed25519@1.7.3': {}
 
   '@noble/hashes@1.1.5': {}
@@ -4444,6 +4503,10 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -4858,6 +4921,8 @@ snapshots:
 
   '@scure/base@2.0.0': {}
 
+  '@scure/base@2.2.0': {}
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
@@ -4870,11 +4935,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@scure/bip32@2.0.1':
+  '@scure/bip32@2.2.0':
     dependencies:
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
-      '@scure/base': 2.0.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@scure/bip39@1.3.0':
     dependencies:
@@ -4886,10 +4951,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@scure/bip39@2.0.1':
+  '@scure/bip39@2.2.0':
     dependencies:
-      '@noble/hashes': 2.0.1
-      '@scure/base': 2.0.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@scure/sr25519@0.2.0':
     dependencies:
@@ -6326,7 +6391,7 @@ snapshots:
       eslint: 9.26.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint@9.26.0))(eslint@9.26.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@9.26.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint@9.26.0))(eslint@9.26.0))(eslint@9.26.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.26.0)
       eslint-plugin-react: 7.37.4(eslint@9.26.0)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.26.0)
@@ -6359,7 +6424,7 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@9.26.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint@9.26.0))(eslint@9.26.0))(eslint@9.26.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6374,7 +6439,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@9.26.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.26.0)(typescript@5.8.3))(eslint@9.26.0))(eslint@9.26.0))(eslint@9.26.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6883,19 +6948,19 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  gql.tada@1.9.0(graphql@16.12.0)(typescript@5.8.3):
+  gql.tada@1.11.3(graphql@16.14.2)(typescript@5.8.3):
     dependencies:
-      '@0no-co/graphql.web': 1.1.2(graphql@16.12.0)
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.12.0)(typescript@5.8.3)
-      '@gql.tada/cli-utils': 1.7.2(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.8.3))(graphql@16.12.0)(typescript@5.8.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.8.3)
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.8.3)
+      '@gql.tada/cli-utils': 1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.8.3))(graphql@16.14.2)(typescript@5.8.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - graphql
 
-  graphql@16.12.0: {}
+  graphql@16.14.2: {}
 
   h3@1.15.5:
     dependencies:
@@ -8476,6 +8541,10 @@ snapshots:
   uuid@8.3.2: {}
 
   valibot@1.2.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
+  valibot@1.4.2(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
 

--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -2624,12 +2624,6 @@ export function JsonRpcContextProvider({
         const [coin] = tx.splitCoins(tx.gas, [100]); // 0.001 SUI
         tx.setSender(address);
         tx.transferObjects([coin], recipient?.trim() || address);
-        // Set an explicit gas budget so build() skips its dry-run simulation.
-        // The installed @mysten/sui `simulateTransaction` query requests a
-        // `SimulationResult.error` field the current Sui GraphQL schema no longer
-        // exposes, so auto gas estimation throws "Unknown field 'error' on type
-        // 'SimulationResult'". 0.01 SUI is ample for this transfer.
-        tx.setGasBudget(10_000_000);
 
         const suiClient = getSuiClient(chainId);
         const bcsTransaction = await tx.build({ client: suiClient });
@@ -2671,11 +2665,6 @@ export function JsonRpcContextProvider({
         tx.setSender(address);
 
         tx.transferObjects([coin], address);
-
-        // Explicit gas budget so build() skips the dry-run simulation, whose
-        // query is incompatible with the current Sui GraphQL schema (see
-        // testSendSuiTransaction above).
-        tx.setGasBudget(10_000_000);
 
         const suiClient = getSuiClient(chainId);
 

--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -2624,6 +2624,12 @@ export function JsonRpcContextProvider({
         const [coin] = tx.splitCoins(tx.gas, [100]); // 0.001 SUI
         tx.setSender(address);
         tx.transferObjects([coin], recipient?.trim() || address);
+        // Set an explicit gas budget so build() skips its dry-run simulation.
+        // The installed @mysten/sui `simulateTransaction` query requests a
+        // `SimulationResult.error` field the current Sui GraphQL schema no longer
+        // exposes, so auto gas estimation throws "Unknown field 'error' on type
+        // 'SimulationResult'". 0.01 SUI is ample for this transfer.
+        tx.setGasBudget(10_000_000);
 
         const suiClient = getSuiClient(chainId);
         const bcsTransaction = await tx.build({ client: suiClient });
@@ -2665,6 +2671,11 @@ export function JsonRpcContextProvider({
         tx.setSender(address);
 
         tx.transferObjects([coin], address);
+
+        // Explicit gas budget so build() skips the dry-run simulation, whose
+        // query is incompatible with the current Sui GraphQL schema (see
+        // testSendSuiTransaction above).
+        tx.setGasBudget(10_000_000);
 
         const suiClient = getSuiClient(chainId);
 

--- a/advanced/dapps/react-dapp-v2/src/helpers/api.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/api.ts
@@ -281,7 +281,7 @@ export const apiGetSuiAccountBalance = async (
   });
 
   return {
-    balance: (parseInt(result.totalBalance) / 10 ** 9).toString(),
+    balance: (parseInt(result.balance.balance) / 10 ** 9).toString(),
     symbol: "SUI",
     name: "SUI",
   };

--- a/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
@@ -1,7 +1,26 @@
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { SuiJsonRpcClient, JsonRpcHTTPTransport } from "@mysten/sui/jsonRpc";
 import { getProviderUrl } from "./utilities";
 
 const clients = new Map<string, SuiJsonRpcClient>();
+
+// The @mysten/sui HTTP transport attaches Client-Sdk-Type / Client-Sdk-Version /
+// Client-Target-Api-Version / Client-Request-Method headers to every request.
+// The WalletConnect Blockchain API's CORS policy does not allow those header
+// names, so the browser rejects the preflight. They are informational only, so
+// strip them here — only Content-Type (which is allowed) needs to survive.
+const blockchainApiFetch: typeof fetch = (input, init) => {
+  if (init?.headers) {
+    const headers = new Headers(init.headers);
+    [
+      "client-sdk-type",
+      "client-sdk-version",
+      "client-target-api-version",
+      "client-request-method",
+    ].forEach((header) => headers.delete(header));
+    init = { ...init, headers };
+  }
+  return fetch(input, init);
+};
 
 export function getSuiClient(chainId: string): SuiJsonRpcClient {
   if (clients.has(chainId)) {
@@ -11,17 +30,20 @@ export function getSuiClient(chainId: string): SuiJsonRpcClient {
   // The public Sui fullnodes (fullnode.*.sui.io) do not return CORS headers, so
   // calling them directly from the browser is blocked, which breaks balance
   // fetching and transaction building (tx.build needs the reference gas price).
-  const url = getProviderUrl(chainId);
+  const transport = new JsonRpcHTTPTransport({
+    url: getProviderUrl(chainId),
+    fetch: blockchainApiFetch,
+  });
   let client: SuiJsonRpcClient;
   switch (chainId) {
     case "sui:mainnet":
-      client = new SuiJsonRpcClient({ network: "mainnet", url });
+      client = new SuiJsonRpcClient({ network: "mainnet", transport });
       break;
     case "sui:testnet":
-      client = new SuiJsonRpcClient({ network: "testnet", url });
+      client = new SuiJsonRpcClient({ network: "testnet", transport });
       break;
     case "sui:devnet":
-      client = new SuiJsonRpcClient({ network: "devnet", url });
+      client = new SuiJsonRpcClient({ network: "devnet", transport });
       break;
     default:
       throw new Error(`Unknown chainId: ${chainId}`);

--- a/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
@@ -1,4 +1,5 @@
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { getProviderUrl } from "./utilities";
 
 const clients = new Map<string, SuiJsonRpcClient>();
 
@@ -6,16 +7,21 @@ export function getSuiClient(chainId: string): SuiJsonRpcClient {
   if (clients.has(chainId)) {
     return clients.get(chainId)!;
   }
+  // Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API.
+  // The public Sui fullnodes (fullnode.*.sui.io) do not return CORS headers, so
+  // calling them directly from the browser is blocked, which breaks balance
+  // fetching and transaction building (tx.build needs the reference gas price).
+  const url = getProviderUrl(chainId);
   let client: SuiJsonRpcClient;
   switch (chainId) {
     case "sui:mainnet":
-      client = new SuiJsonRpcClient({ network: "mainnet", url: "https://fullnode.mainnet.sui.io/" });
+      client = new SuiJsonRpcClient({ network: "mainnet", url });
       break;
     case "sui:testnet":
-      client = new SuiJsonRpcClient({ network: "testnet", url: "https://fullnode.testnet.sui.io/" });
+      client = new SuiJsonRpcClient({ network: "testnet", url });
       break;
     case "sui:devnet":
-      client = new SuiJsonRpcClient({ network: "devnet", url: "https://fullnode.devnet.sui.io/" });
+      client = new SuiJsonRpcClient({ network: "devnet", url });
       break;
     default:
       throw new Error(`Unknown chainId: ${chainId}`);

--- a/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
@@ -16,10 +16,6 @@ export function getSuiClient(chainId: string): SuiGraphQLClient {
   if (!network) {
     throw new Error(`Unknown chainId: ${chainId}`);
   }
-  // Sui disabled JSON-RPC on its public fullnodes (2026-07-27), so the SDK's
-  // SuiJsonRpcClient no longer works. Use the GraphQL RPC — the recommended
-  // browser/frontend replacement — which is CORS-enabled out of the box.
-  // https://docs.sui.io/develop/accessing-data/json-rpc-migration
   const client = new SuiGraphQLClient({
     network,
     url: `https://graphql.${network}.sui.io/graphql`,

--- a/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/sui.ts
@@ -1,53 +1,29 @@
-import { SuiJsonRpcClient, JsonRpcHTTPTransport } from "@mysten/sui/jsonRpc";
-import { getProviderUrl } from "./utilities";
+import { SuiGraphQLClient } from "@mysten/sui/graphql";
 
-const clients = new Map<string, SuiJsonRpcClient>();
+const clients = new Map<string, SuiGraphQLClient>();
 
-// The @mysten/sui HTTP transport attaches Client-Sdk-Type / Client-Sdk-Version /
-// Client-Target-Api-Version / Client-Request-Method headers to every request.
-// The WalletConnect Blockchain API's CORS policy does not allow those header
-// names, so the browser rejects the preflight. They are informational only, so
-// strip them here — only Content-Type (which is allowed) needs to survive.
-const blockchainApiFetch: typeof fetch = (input, init) => {
-  if (init?.headers) {
-    const headers = new Headers(init.headers);
-    [
-      "client-sdk-type",
-      "client-sdk-version",
-      "client-target-api-version",
-      "client-request-method",
-    ].forEach((header) => headers.delete(header));
-    init = { ...init, headers };
-  }
-  return fetch(input, init);
+const SUI_NETWORKS: Record<string, "mainnet" | "testnet" | "devnet"> = {
+  "sui:mainnet": "mainnet",
+  "sui:testnet": "testnet",
+  "sui:devnet": "devnet",
 };
 
-export function getSuiClient(chainId: string): SuiJsonRpcClient {
+export function getSuiClient(chainId: string): SuiGraphQLClient {
   if (clients.has(chainId)) {
     return clients.get(chainId)!;
   }
-  // Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API.
-  // The public Sui fullnodes (fullnode.*.sui.io) do not return CORS headers, so
-  // calling them directly from the browser is blocked, which breaks balance
-  // fetching and transaction building (tx.build needs the reference gas price).
-  const transport = new JsonRpcHTTPTransport({
-    url: getProviderUrl(chainId),
-    fetch: blockchainApiFetch,
-  });
-  let client: SuiJsonRpcClient;
-  switch (chainId) {
-    case "sui:mainnet":
-      client = new SuiJsonRpcClient({ network: "mainnet", transport });
-      break;
-    case "sui:testnet":
-      client = new SuiJsonRpcClient({ network: "testnet", transport });
-      break;
-    case "sui:devnet":
-      client = new SuiJsonRpcClient({ network: "devnet", transport });
-      break;
-    default:
-      throw new Error(`Unknown chainId: ${chainId}`);
+  const network = SUI_NETWORKS[chainId];
+  if (!network) {
+    throw new Error(`Unknown chainId: ${chainId}`);
   }
+  // Sui disabled JSON-RPC on its public fullnodes (2026-07-27), so the SDK's
+  // SuiJsonRpcClient no longer works. Use the GraphQL RPC — the recommended
+  // browser/frontend replacement — which is CORS-enabled out of the box.
+  // https://docs.sui.io/develop/accessing-data/json-rpc-migration
+  const client = new SuiGraphQLClient({
+    network,
+    url: `https://graphql.${network}.sui.io/graphql`,
+  });
   clients.set(chainId, client);
   return client;
 }

--- a/advanced/wallets/react-wallet-v2/package.json
+++ b/advanced/wallets/react-wallet-v2/package.json
@@ -26,7 +26,7 @@
     "@mui/material": "5.18.0",
     "@multiversx/sdk-core": "15.3.2",
     "@multiversx/sdk-wallet": "4.2.0",
-    "@mysten/sui": "2.1.0",
+    "@mysten/sui": "2.23.2",
     "@near-wallet-selector/wallet-utils": "8.10.2",
     "@nextui-org/react": "1.0.8-beta.5",
     "@noble/curves": "1.9.7",

--- a/advanced/wallets/react-wallet-v2/pnpm-lock.yaml
+++ b/advanced/wallets/react-wallet-v2/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       '@mysten/sui':
-        specifier: 2.1.0
-        version: 2.1.0(typescript@5.4.5)
+        specifier: 2.23.2
+        version: 2.23.2(typescript@5.4.5)
       '@near-wallet-selector/wallet-utils':
         specifier: 8.10.2
         version: 8.10.2(near-api-js@0.45.1)
@@ -298,19 +298,19 @@ importers:
 
 packages:
 
-  '@0no-co/graphql.web@1.2.0':
-    resolution: {integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==}
+  '@0no-co/graphql.web@1.3.3':
+    resolution: {integrity: sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     peerDependenciesMeta:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.15.2':
-    resolution: {integrity: sha512-Ys031WnS3sTQQBtRTkQsYnw372OlW72ais4sp0oh2UMPRNyxxnq85zRfU4PIdoy9kWriysPT5BYAkgIxhbonFA==}
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@adraffy/ens-normalize@1.10.0':
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
@@ -661,25 +661,25 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
-  '@gql.tada/cli-utils@1.7.2':
-    resolution: {integrity: sha512-Qbc7hbLvCz6IliIJpJuKJa9p05b2Jona7ov7+qofCsMRxHRZE1kpAmZMvL8JCI4c0IagpIlWNaMizXEQUe8XjQ==}
+  '@gql.tada/cli-utils@1.9.3':
+    resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
     peerDependencies:
-      '@0no-co/graphqlsp': ^1.12.13
-      '@gql.tada/svelte-support': 1.0.1
-      '@gql.tada/vue-support': 1.0.1
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@gql.tada/svelte-support':
         optional: true
       '@gql.tada/vue-support':
         optional: true
 
-  '@gql.tada/internal@1.0.8':
-    resolution: {integrity: sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==}
+  '@gql.tada/internal@1.2.2':
+    resolution: {integrity: sha512-4lZcElPP6MC8Ct8KN70LR2WQsHjbAsyAmTGG09VsOPhx738UFIYaL0S1XiI2pqq2tj/sDs/y3b9jvKoWGL7iuQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -732,89 +732,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1066,15 +1082,15 @@ packages:
     resolution: {integrity: sha512-EjSb9AnqMcpmDjZ7ebkUpOzpTfxj1plTuVXwZ6AaqJsdpxMfrE2izbPy18+bg5xFlr8V27wYZcW8zOhkBR50BA==}
     deprecated: The functionality has been integrated into @multiversx/sdk-core, thus this package is no longer supported.
 
-  '@mysten/bcs@2.0.1':
-    resolution: {integrity: sha512-/q1uC5Vw/RjXzR4fE9QiIwmTvRx9BstduxkR1j1Z5EbE7ZJynLkFKcJJlXRcnnEytIPcsyiR+TkQixzSbz3msQ==}
+  '@mysten/bcs@2.1.0':
+    resolution: {integrity: sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==}
 
-  '@mysten/sui@2.1.0':
-    resolution: {integrity: sha512-q1keHOsvNrkfM+rCUHJRFDHagrdr7rCIsNGhM9NrtShAMtCEgCiChuCFGHGVjb3/J2CFj+SxPIG5fEb5bj+9UQ==}
+  '@mysten/sui@2.23.2':
+    resolution: {integrity: sha512-cUnE4v/0NSKsdihU09qmSS82pqlRPb6XjPO+iU5KAqSn5rRsEcbJZ/lTsW1INfnmWeHs6/Xobv+vEedDlQ1CZw==}
     engines: {node: '>=22'}
 
-  '@mysten/utils@0.3.0':
-    resolution: {integrity: sha512-paVyFTP+1yHXDO8uorU6YuT1EAIh/GMKXeHbxtGFPJbLzwc5jk1qfUMrks/S7MAwJHMOHcSOx+e2Mwx8ejaIew==}
+  '@mysten/utils@0.4.0':
+    resolution: {integrity: sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1112,24 +1128,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1175,8 +1195,12 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@noble/curves@2.0.1':
-    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.3.0':
+    resolution: {integrity: sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/ed25519@1.7.3':
@@ -1207,8 +1231,12 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@noble/hashes@2.0.1':
-    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/secp256k1@1.7.1':
@@ -1644,8 +1672,8 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
-  '@scure/base@2.0.0':
-    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@scure/bip32@1.1.3':
     resolution: {integrity: sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==}
@@ -1656,8 +1684,8 @@ packages:
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
-  '@scure/bip32@2.0.1':
-    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
 
   '@scure/bip39@1.1.0':
     resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
@@ -1668,8 +1696,8 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@scure/bip39@2.0.1':
-    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
@@ -2390,41 +2418,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3036,6 +3072,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-color-keywords@1.0.0:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
@@ -3604,14 +3641,18 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  gql.tada@1.9.0:
-    resolution: {integrity: sha512-1LMiA46dRs5oF7Qev6vMU32gmiNvM3+3nHoQZA9K9j2xQzH8xOAWnnJrLSbZOFHTSdFxqn86TL6beo1/7ja/aA==}
+  gql.tada@1.11.3:
+    resolution: {integrity: sha512-5JCI4j2f0nug8ILaCQys/yjOP78QqqjVUf47OQsME63rZfemsHT3e5vcfbHsnZiG6vxyqpKUJArtXEVwSefUhw==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   h3@1.15.5:
@@ -5085,8 +5126,8 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -5329,14 +5370,14 @@ packages:
 
 snapshots:
 
-  '@0no-co/graphql.web@1.2.0(graphql@16.12.0)':
+  '@0no-co/graphql.web@1.3.3(graphql@16.14.2)':
     optionalDependencies:
-      graphql: 16.12.0
+      graphql: 16.14.2
 
-  '@0no-co/graphqlsp@1.15.2(graphql@16.12.0)(typescript@5.4.5)':
+  '@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.4.5)':
     dependencies:
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.4.5)
-      graphql: 16.12.0
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.4.5)
+      graphql: 16.14.2
       typescript: 5.4.5
 
   '@adraffy/ens-normalize@1.10.0': {}
@@ -6013,22 +6054,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@gql.tada/cli-utils@1.7.2(@0no-co/graphqlsp@1.15.2(graphql@16.12.0)(typescript@5.4.5))(graphql@16.12.0)(typescript@5.4.5)':
+  '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.4.5))(graphql@16.14.2)(typescript@5.4.5)':
     dependencies:
-      '@0no-co/graphqlsp': 1.15.2(graphql@16.12.0)(typescript@5.4.5)
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.4.5)
-      graphql: 16.12.0
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.4.5)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.4.5)
+      graphql: 16.14.2
       typescript: 5.4.5
 
-  '@gql.tada/internal@1.0.8(graphql@16.12.0)(typescript@5.4.5)':
+  '@gql.tada/internal@1.2.2(graphql@16.14.2)(typescript@5.4.5)':
     dependencies:
-      '@0no-co/graphql.web': 1.2.0(graphql@16.12.0)
-      graphql: 16.12.0
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      graphql: 16.14.2
       typescript: 5.4.5
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
     dependencies:
-      graphql: 16.12.0
+      graphql: 16.14.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -6411,36 +6452,36 @@ snapshots:
       tweetnacl: 1.0.3
       uuid: 8.3.2
 
-  '@mysten/bcs@2.0.1':
+  '@mysten/bcs@2.1.0':
     dependencies:
-      '@mysten/utils': 0.3.0
-      '@scure/base': 2.0.0
+      '@mysten/utils': 0.4.0
+      '@scure/base': 2.2.0
 
-  '@mysten/sui@2.1.0(typescript@5.4.5)':
+  '@mysten/sui@2.23.2(typescript@5.4.5)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
-      '@mysten/bcs': 2.0.1
-      '@mysten/utils': 0.3.0
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@mysten/bcs': 2.1.0
+      '@mysten/utils': 0.4.0
+      '@noble/curves': 2.3.0
+      '@noble/hashes': 2.3.0
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
-      '@scure/base': 2.0.0
-      '@scure/bip32': 2.0.1
-      '@scure/bip39': 2.0.1
-      gql.tada: 1.9.0(graphql@16.12.0)(typescript@5.4.5)
-      graphql: 16.12.0
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.11.3(graphql@16.14.2)(typescript@5.4.5)
+      graphql: 16.14.2
       poseidon-lite: 0.2.1
-      valibot: 1.2.0(typescript@5.4.5)
+      valibot: 1.4.2(typescript@5.4.5)
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - typescript
 
-  '@mysten/utils@0.3.0':
+  '@mysten/utils@0.4.0':
     dependencies:
-      '@scure/base': 2.0.0
+      '@scure/base': 2.2.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -6543,9 +6584,13 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@noble/curves@2.0.1':
+  '@noble/curves@2.2.0':
     dependencies:
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
+
+  '@noble/curves@2.3.0':
+    dependencies:
+      '@noble/hashes': 2.3.0
 
   '@noble/ed25519@1.7.3': {}
 
@@ -6563,7 +6608,9 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@noble/hashes@2.0.1': {}
+  '@noble/hashes@2.2.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -7472,7 +7519,7 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
-  '@scure/base@2.0.0': {}
+  '@scure/base@2.2.0': {}
 
   '@scure/bip32@1.1.3':
     dependencies:
@@ -7492,11 +7539,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@scure/bip32@2.0.1':
+  '@scure/bip32@2.2.0':
     dependencies:
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
-      '@scure/base': 2.0.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@scure/bip39@1.1.0':
     dependencies:
@@ -7513,10 +7560,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@scure/bip39@2.0.1':
+  '@scure/bip39@2.2.0':
     dependencies:
-      '@noble/hashes': 2.0.1
-      '@scure/base': 2.0.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(utf-8-validate@5.0.10))':
     dependencies:
@@ -9854,7 +9901,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2)
@@ -9897,7 +9944,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9912,7 +9959,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10324,12 +10371,12 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  gql.tada@1.9.0(graphql@16.12.0)(typescript@5.4.5):
+  gql.tada@1.11.3(graphql@16.14.2)(typescript@5.4.5):
     dependencies:
-      '@0no-co/graphql.web': 1.2.0(graphql@16.12.0)
-      '@0no-co/graphqlsp': 1.15.2(graphql@16.12.0)(typescript@5.4.5)
-      '@gql.tada/cli-utils': 1.7.2(@0no-co/graphqlsp@1.15.2(graphql@16.12.0)(typescript@5.4.5))(graphql@16.12.0)(typescript@5.4.5)
-      '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.4.5)
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.4.5)
+      '@gql.tada/cli-utils': 1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.4.5))(graphql@16.14.2)(typescript@5.4.5)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
@@ -10337,6 +10384,8 @@ snapshots:
       - graphql
 
   graphql@16.12.0: {}
+
+  graphql@16.14.2: {}
 
   h3@1.15.5:
     dependencies:
@@ -12030,7 +12079,7 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  valibot@1.2.0(typescript@5.4.5):
+  valibot@1.4.2(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 

--- a/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
@@ -15,11 +15,6 @@ export type ISuiChainId =
   | typeof SUI_TESTNET_CAIP2
   | typeof SUI_DEVNET_CAIP2
 
-/**
- * Sui disabled JSON-RPC on its public fullnodes (2026-07-27), so use the GraphQL
- * RPC — the recommended browser/frontend replacement, which is CORS-enabled out
- * of the box. https://docs.sui.io/develop/accessing-data/json-rpc-migration
- */
 export const getSuiGraphqlUrl = (caip2: ISuiChainId) => {
   const network = caip2.split(':')[1]
   return `https://graphql.${network}.sui.io/graphql`

--- a/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
@@ -16,12 +16,13 @@ export type ISuiChainId =
   | typeof SUI_DEVNET_CAIP2
 
 /**
- * Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API.
- * The public Sui fullnodes (fullnode.*.sui.io) do not return CORS headers, so
- * calling them directly from the browser is blocked.
+ * Sui disabled JSON-RPC on its public fullnodes (2026-07-27), so use the GraphQL
+ * RPC — the recommended browser/frontend replacement, which is CORS-enabled out
+ * of the box. https://docs.sui.io/develop/accessing-data/json-rpc-migration
  */
-export const getSuiRpcUrl = (caip2: ISuiChainId) => {
-  return `https://rpc.walletconnect.org/v1?chainId=${caip2}&projectId=${process.env.NEXT_PUBLIC_PROJECT_ID}`
+export const getSuiGraphqlUrl = (caip2: ISuiChainId) => {
+  const network = caip2.split(':')[1]
+  return `https://graphql.${network}.sui.io/graphql`
 }
 
 export const SUI_MAINNET = {
@@ -30,7 +31,7 @@ export const SUI_MAINNET = {
     name: 'SUI Mainnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: getSuiRpcUrl(SUI_MAINNET_CAIP2),
+    rpc: getSuiGraphqlUrl(SUI_MAINNET_CAIP2),
     caip2: SUI_MAINNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'
@@ -42,7 +43,7 @@ export const SUI_TESTNET = {
     name: 'SUI Testnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: getSuiRpcUrl(SUI_TESTNET_CAIP2),
+    rpc: getSuiGraphqlUrl(SUI_TESTNET_CAIP2),
     caip2: SUI_TESTNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'
@@ -54,7 +55,7 @@ export const SUI_DEVNET = {
     name: 'SUI Devnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: getSuiRpcUrl(SUI_DEVNET_CAIP2),
+    rpc: getSuiGraphqlUrl(SUI_DEVNET_CAIP2),
     caip2: SUI_DEVNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'

--- a/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/SuiData.ts
@@ -15,13 +15,22 @@ export type ISuiChainId =
   | typeof SUI_TESTNET_CAIP2
   | typeof SUI_DEVNET_CAIP2
 
+/**
+ * Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API.
+ * The public Sui fullnodes (fullnode.*.sui.io) do not return CORS headers, so
+ * calling them directly from the browser is blocked.
+ */
+export const getSuiRpcUrl = (caip2: ISuiChainId) => {
+  return `https://rpc.walletconnect.org/v1?chainId=${caip2}&projectId=${process.env.NEXT_PUBLIC_PROJECT_ID}`
+}
+
 export const SUI_MAINNET = {
   [SUI_MAINNET_CAIP2]: {
     chainId: SUI_MAINNET_ID,
     name: 'SUI Mainnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: 'https://fullnode.mainnet.sui.io:443',
+    rpc: getSuiRpcUrl(SUI_MAINNET_CAIP2),
     caip2: SUI_MAINNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'
@@ -33,7 +42,7 @@ export const SUI_TESTNET = {
     name: 'SUI Testnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: 'https://fullnode.testnet.sui.io:443',
+    rpc: getSuiRpcUrl(SUI_TESTNET_CAIP2),
     caip2: SUI_TESTNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'
@@ -45,7 +54,7 @@ export const SUI_DEVNET = {
     name: 'SUI Devnet',
     logo: '/chain-logos/sui.png',
     rgb: '6, 135, 245',
-    rpc: 'https://fullnode.devnet.sui.io:443',
+    rpc: getSuiRpcUrl(SUI_DEVNET_CAIP2),
     caip2: SUI_DEVNET_CAIP2 as ISuiChainId,
     namespace: SUI_NAMESPACE,
     symbol: 'SUI'

--- a/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
@@ -4,24 +4,8 @@ import { Ed25519Keypair, Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
 import { verifyPersonalMessageSignature } from '@mysten/sui/verify'
 import { derivePath } from 'ed25519-hd-key'
 import { SerialTransactionExecutor, Transaction } from '@mysten/sui/transactions'
-import { SuiJsonRpcClient, JsonRpcHTTPTransport } from '@mysten/sui/jsonRpc'
-import { getSuiRpcUrl } from '@/data/SuiData'
-
-// The @mysten/sui HTTP transport attaches Client-Sdk-Type / Client-Sdk-Version /
-// Client-Target-Api-Version / Client-Request-Method headers to every request.
-// The WalletConnect Blockchain API's CORS policy does not allow those header
-// names, so the browser rejects the preflight. They are informational only, so
-// strip them here — only Content-Type (which is allowed) needs to survive.
-const blockchainApiFetch: typeof fetch = (input, init) => {
-  if (init?.headers) {
-    const headers = new Headers(init.headers)
-    ;['client-sdk-type', 'client-sdk-version', 'client-target-api-version', 'client-request-method'].forEach(
-      header => headers.delete(header)
-    )
-    init = { ...init, headers }
-  }
-  return fetch(input, init)
-}
+import { SuiGraphQLClient } from '@mysten/sui/graphql'
+import { getSuiGraphqlUrl } from '@/data/SuiData'
 
 interface IInitArguments {
   mnemonic?: string
@@ -49,7 +33,7 @@ const SUI_PATH = "m/44'/784'/0'/0'/0'"
 export default class SuiLib {
   private keypair: Ed25519Keypair
   private mnemonic: string
-  private suiClients: Record<string, SuiJsonRpcClient> = {}
+  private suiClients: Record<string, SuiGraphQLClient> = {}
   private publicKey: Ed25519PublicKey
 
   constructor(mnemonic?: string) {
@@ -131,26 +115,17 @@ export default class SuiLib {
       return this.suiClients[chainId]
     }
 
-    // Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API
-    // rather than the public Sui fullnodes, which are blocked in the browser.
+    // Sui disabled JSON-RPC on its public fullnodes (2026-07-27); use the
+    // CORS-enabled GraphQL RPC instead (see getSuiGraphqlUrl in SuiData).
     switch (chainId) {
       case 'sui:mainnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({
-          network: 'mainnet',
-          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
-        })
+        this.suiClients[chainId] = new SuiGraphQLClient({ url: getSuiGraphqlUrl(chainId), network: 'mainnet' })
         break
       case 'sui:testnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({
-          network: 'testnet',
-          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
-        })
+        this.suiClients[chainId] = new SuiGraphQLClient({ url: getSuiGraphqlUrl(chainId), network: 'testnet' })
         break
       case 'sui:devnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({
-          network: 'devnet',
-          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
-        })
+        this.suiClients[chainId] = new SuiGraphQLClient({ url: getSuiGraphqlUrl(chainId), network: 'devnet' })
         break
       default:
         throw new Error(`Unknown chainId: ${chainId}`)

--- a/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
@@ -4,8 +4,24 @@ import { Ed25519Keypair, Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
 import { verifyPersonalMessageSignature } from '@mysten/sui/verify'
 import { derivePath } from 'ed25519-hd-key'
 import { SerialTransactionExecutor, Transaction } from '@mysten/sui/transactions'
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
+import { SuiJsonRpcClient, JsonRpcHTTPTransport } from '@mysten/sui/jsonRpc'
 import { getSuiRpcUrl } from '@/data/SuiData'
+
+// The @mysten/sui HTTP transport attaches Client-Sdk-Type / Client-Sdk-Version /
+// Client-Target-Api-Version / Client-Request-Method headers to every request.
+// The WalletConnect Blockchain API's CORS policy does not allow those header
+// names, so the browser rejects the preflight. They are informational only, so
+// strip them here — only Content-Type (which is allowed) needs to survive.
+const blockchainApiFetch: typeof fetch = (input, init) => {
+  if (init?.headers) {
+    const headers = new Headers(init.headers)
+    ;['client-sdk-type', 'client-sdk-version', 'client-target-api-version', 'client-request-method'].forEach(
+      header => headers.delete(header)
+    )
+    init = { ...init, headers }
+  }
+  return fetch(input, init)
+}
 
 interface IInitArguments {
   mnemonic?: string
@@ -119,13 +135,22 @@ export default class SuiLib {
     // rather than the public Sui fullnodes, which are blocked in the browser.
     switch (chainId) {
       case 'sui:mainnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'mainnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({
+          network: 'mainnet',
+          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
+        })
         break
       case 'sui:testnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'testnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({
+          network: 'testnet',
+          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
+        })
         break
       case 'sui:devnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'devnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({
+          network: 'devnet',
+          transport: new JsonRpcHTTPTransport({ url: getSuiRpcUrl(chainId), fetch: blockchainApiFetch })
+        })
         break
       default:
         throw new Error(`Unknown chainId: ${chainId}`)

--- a/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
@@ -5,6 +5,7 @@ import { verifyPersonalMessageSignature } from '@mysten/sui/verify'
 import { derivePath } from 'ed25519-hd-key'
 import { SerialTransactionExecutor, Transaction } from '@mysten/sui/transactions'
 import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
+import { getSuiRpcUrl } from '@/data/SuiData'
 
 interface IInitArguments {
   mnemonic?: string
@@ -114,15 +115,17 @@ export default class SuiLib {
       return this.suiClients[chainId]
     }
 
+    // Route Sui JSON-RPC through the CORS-enabled WalletConnect Blockchain API
+    // rather than the public Sui fullnodes, which are blocked in the browser.
     switch (chainId) {
       case 'sui:mainnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: 'https://fullnode.mainnet.sui.io/', network: 'mainnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'mainnet' })
         break
       case 'sui:testnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: 'https://fullnode.testnet.sui.io/', network: 'testnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'testnet' })
         break
       case 'sui:devnet':
-        this.suiClients[chainId] = new SuiJsonRpcClient({ url: 'https://fullnode.devnet.sui.io/', network: 'devnet' })
+        this.suiClients[chainId] = new SuiJsonRpcClient({ url: getSuiRpcUrl(chainId), network: 'devnet' })
         break
       default:
         throw new Error(`Unknown chainId: ${chainId}`)

--- a/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts
@@ -115,8 +115,6 @@ export default class SuiLib {
       return this.suiClients[chainId]
     }
 
-    // Sui disabled JSON-RPC on its public fullnodes (2026-07-27); use the
-    // CORS-enabled GraphQL RPC instead (see getSuiGraphqlUrl in SuiData).
     switch (chainId) {
       case 'sui:mainnet':
         this.suiClients[chainId] = new SuiGraphQLClient({ url: getSuiGraphqlUrl(chainId), network: 'mainnet' })

--- a/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
@@ -198,23 +198,26 @@ async function fetchSolanaBalance(address: string, rpc: string, chainId: string)
 async function fetchSuiBalance(address: string, rpc: string, chainId: string): Promise<BalanceResult> {
   const symbol = getSymbol(chainId)
   const actualAddress = extractAddressFromCaip10(address)
+  // Sui disabled JSON-RPC on its public fullnodes (2026-07-27); query the GraphQL RPC.
   const response = await fetch(rpc, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'suix_getBalance',
-      params: [actualAddress, '0x2::sui::SUI']
+      query: `query($address: SuiAddress!) {
+        address(address: $address) {
+          balance(coinType: "0x2::sui::SUI") { totalBalance }
+        }
+      }`,
+      variables: { address: actualAddress }
     })
   })
 
   const data = await response.json()
-  if (data.error) {
-    throw new Error(data.error.message)
+  if (data.errors?.length) {
+    throw new Error(data.errors[0].message)
   }
 
-  const totalBalance = data.result?.totalBalance || '0'
+  const totalBalance = data.data?.address?.balance?.totalBalance || '0'
   const balance = (BigInt(totalBalance) / BigInt(1e9)).toString()
   const preciseBalance = Number(totalBalance) / 1e9
   return { balance, balanceFormatted: formatBalanceValue(preciseBalance.toString()), symbol }

--- a/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
@@ -198,7 +198,6 @@ async function fetchSolanaBalance(address: string, rpc: string, chainId: string)
 async function fetchSuiBalance(address: string, rpc: string, chainId: string): Promise<BalanceResult> {
   const symbol = getSymbol(chainId)
   const actualAddress = extractAddressFromCaip10(address)
-  // Sui disabled JSON-RPC on its public fullnodes (2026-07-27); query the GraphQL RPC.
   const response = await fetch(rpc, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Problem

Reported by Nelson: connecting a dApp to a Sui Mainnet account and using the Sui methods fails in the browser. The symptom started as CORS errors, but the underlying cause turned out to be deeper.

## Root cause (the real one)

**Sui disabled JSON-RPC on its public fullnodes on 2026-07-27** (full decommission mid-October 2026 — see the [migration notice](https://docs.sui.io/develop/accessing-data/json-rpc-migration)). Every JSON-RPC method now returns:

```
-32601 Method not found. JSON-RPC on public fullnodes has been deprecated.
Please migrate to gRPC or GraphQL endpoints.
```

The examples used `@mysten/sui`'s `SuiJsonRpcClient`, so Sui balance fetching and transaction building/execution are all broken. The WalletConnect Blockchain API doesn't help here — it only proxies the now-dead JSON-RPC.

Along the way this surfaced two real CORS bugs that were masking the deprecation (the examples talked to `fullnode.*.sui.io` directly, which sends no `Access-Control-Allow-Origin`); those are moot now that we no longer use JSON-RPC at all.

## Fix

Migrate the Sui client from JSON-RPC to Sui's **GraphQL RPC** — the recommended frontend replacement — pointed at the public endpoint `https://graphql.<network>.sui.io/graphql`, which is **CORS-enabled out of the box** (`access-control-allow-origin: *`, `access-control-allow-headers: *`).

`SuiGraphQLClient` is a drop-in for what the examples need:
- same `{ url, network }` constructor;
- same core API (`getBalance`, `getReferenceGasPrice`, `executeTransaction`);
- `tx.build` / `SerialTransactionExecutor` accept any `ClientWithCoreApi`, and all three transport clients (`SuiJsonRpcClient`, `SuiGraphQLClient`, `SuiGrpcClient`) extend the same `BaseClient`. (The migration doc's "doesn't accept `SuiGrpcClient`" caveat is about `@mysten/dapp-kit`, which these examples don't use for the Sui client.)

```mermaid
flowchart LR
    A[dApp / wallet] -. "❌ -32601 JSON-RPC deprecated (2026-07-27)" .-x B[(fullnode.*.sui.io<br/>JSON-RPC)]
    A -. "❌ proxies the dead JSON-RPC" .-x D[rpc.walletconnect.*<br/>Blockchain API]
    A == "✅ SuiGraphQLClient, CORS-enabled" ==> C[graphql.network.sui.io/graphql<br/>GraphQL RPC]
```

There's also a **SDK-vs-schema drift**: `build()` resolves the transaction via a `simulateTransaction` GraphQL query, and the pinned SDK versions (dApp `2.3.1`, wallet `2.1.0`) requested `SimulationResult.error` — a field the current mainnet schema no longer exposes (it now has only `effects`/`outputs`). So `build()` threw *"Unknown field 'error' on type 'SimulationResult'"*. This resolution query runs on every build regardless of gas budget, so it can't be worked around at the transaction level — the fix is to **upgrade `@mysten/sui` to `2.23.2`**, whose resolver reads execution errors from `effects` and matches the deployed schema.

Files:
- **dApp** — [`helpers/sui.ts`](advanced/dapps/react-dapp-v2/src/helpers/sui.ts) (`getSuiClient` → `SuiGraphQLClient`), [`helpers/api.ts`](advanced/dapps/react-dapp-v2/src/helpers/api.ts) (balance reads `result.balance.balance`), `package.json`/`pnpm-lock.yaml` (`@mysten/sui` → `2.23.2`). `tx.build` in `JsonRpcContext.tsx` is unchanged.
- **Wallet** — [`data/SuiData.ts`](advanced/wallets/react-wallet-v2/src/data/SuiData.ts) (`getSuiGraphqlUrl`), [`lib/SuiLib.ts`](advanced/wallets/react-wallet-v2/src/lib/SuiLib.ts) (`SuiGraphQLClient`), [`utils/BalanceUtil.ts`](advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts) (`fetchSuiBalance` uses a GraphQL query), `package.json`/`pnpm-lock.yaml` (`@mysten/sui` → `2.23.2`).

> The `@mysten/sui` bump was installed with **pnpm 10** so the repo's `pnpm.overrides` (security pins) are preserved — pnpm 11 no longer reads that field and would silently drop them. Lockfile churn is limited to the `@mysten/sui` dependency subtree.

## Verification

- `tsc --noEmit` clean in both apps.
- Verified live against `https://graphql.mainnet.sui.io/graphql`: CORS preflight returns `access-control-allow-origin: *`; `epoch { referenceGasPrice }` (needed by `tx.build`) and `address(...) { balance(coinType) { totalBalance } }` both return real data.
- ⚠️ Not verified end-to-end headlessly: the wallet-side transaction **signing/execution** through the GraphQL client (`SerialTransactionExecutor` / `executeTransaction`). Needs a manual run on the preview.

## Notes
- Public Sui GraphQL endpoints are rate-limited "development / public-good" tier per Sui's docs — fine for these examples; a production integration would use a dedicated provider.
- Branch name (`…cors-blockchain-api`) predates the GraphQL diagnosis; kept to avoid breaking the preview URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
